### PR TITLE
Added support for comment macro

### DIFF
--- a/src/sci/impl/macros.cljc
+++ b/src/sci/impl/macros.cljc
@@ -9,7 +9,7 @@
      merge-meta]]
    [clojure.string :as str]))
 
-(def macros '#{do if when and or -> ->> as-> quote quote* let fn fn* def defn})
+(def macros '#{do if when and or -> ->> as-> quote quote* let fn fn* def defn comment})
 
 (defn allow?! [{:keys [:allow]} sym]
   (let [allowed? (if allow (contains? allow sym)
@@ -201,6 +201,12 @@
     (swap! (:env ctx) assoc fn-name :sci/var.unbound)
     (mark-eval-call (list 'def fn-name f))))
 
+
+(defn expand-comment
+"The comment macro from clojure.core."
+[ctx & body])
+
+
 (defn macroexpand-call [ctx expr]
   (if-let [f (first expr)]
     (if (symbol? f)
@@ -223,6 +229,7 @@
                 ->> (expand->> ctx (rest expr))
                 as-> (expand-as-> ctx expr)
                 quote (do nil #_(prn "quote" expr) (second expr))
+                comment (expand-comment ctx expr)
                 ;; else:
                 (mark-eval-call (doall (map #(macroexpand ctx %) expr)))))
           (mark-eval-call (doall (map #(macroexpand ctx %) expr)))))

--- a/test/sci/core_test.cljc
+++ b/test/sci/core_test.cljc
@@ -244,6 +244,12 @@
                         #"\[at line 1, column 19\]"
                         (tu/eval* "(+ 1 2 3 4 5) (do x)" {}))))
 
+(deftest comment-test
+	(is (nil? (eval* '(comment "anything"))))
+	(is (nil? (eval* '(comment anything))))
+	(is (nil? (eval* '(comment 1))))
+	(is (nil? (eval* '(comment (+ 1 2 (* 3 4)))))))
+
 ;;;; Scratch
 
 (comment


### PR DESCRIPTION

## Changes:

- Added support to interpret and execute comment macro.
- Added respective tests.


## Tests:

- `script/test/all` shows all tests are successful.

- After build from cli,
```
./sci "(comment (+ 1 2 (* 3 4)))"
;; nil

./sci "(comment anything)"

;;nil

```