### PR TITLE
Support PATH native-image on *nix-likes

### DIFF
--- a/script/compile
+++ b/script/compile
@@ -2,18 +2,24 @@
 
 set -eo pipefail
 
-if [ -z "$GRAALVM_HOME" ]; then
-    echo "Please set GRAALVM_HOME"
-    exit 1
-fi
+NATIVE_IMAGE=`which native-image` || true
 
-"$GRAALVM_HOME/bin/gu" install native-image
+if [ -z "$NATIVE_IMAGE" ]; then
+  if [ -z "$GRAALVM_HOME" ]; then
+      echo "Please set GRAALVM_HOME"
+      exit 1
+  fi
+
+  "$GRAALVM_HOME/bin/gu" install native-image || true
+
+  NATIVE_IMAGE="$GRAALVM_HOME/bin/native-image"
+fi
 
 SCI_VERSION=$(cat resources/SCI_VERSION)
 
 lein with-profiles +clojure-1.10.1 do clean, uberjar
 
-$GRAALVM_HOME/bin/native-image \
+$NATIVE_IMAGE \
   -jar target/sci-$SCI_VERSION-standalone.jar \
   -H:Name=sci \
   -H:+ReportExceptionStackTraces \


### PR DESCRIPTION
Tests pass here on Manjaro Linux.

```
$ sh script/test/all
Testing with Clojure 1.9.0
Retrieving criterium/criterium/0.4.5/criterium-0.4.5.pom from clojars
Retrieving com/clojure-goes-fast/clj-async-profiler/0.4.0/clj-async-profiler-0.4.0.pom from clojars
Retrieving criterium/criterium/0.4.5/criterium-0.4.5.jar from clojars
Retrieving com/clojure-goes-fast/clj-async-profiler/0.4.0/clj-async-profiler-0.4.0.jar from clojars

lein test sci.core-test

lein test sci.impl.parser-test

lein test sci.performance
Testing reusable function result.
Evaluation count : 59574 in 6 samples of 9929 calls.
             Execution time mean : 9.490067 µs
    Execution time std-deviation : 934.925902 ns
   Execution time lower quantile : 8.511238 µs ( 2.5%)
   Execution time upper quantile : 10.430967 µs (97.5%)
                   Overhead used : 7.797252 ns


lein test sci.test-utils

Ran 22 tests containing 120 assertions.
0 failures, 0 errors.
Testing with Clojure 1.10.1

lein test sci.core-test

lein test sci.impl.parser-test

lein test sci.performance
Testing reusable function result.
Evaluation count : 66288 in 6 samples of 11048 calls.
             Execution time mean : 13.806718 µs
    Execution time std-deviation : 4.119888 µs
   Execution time lower quantile : 9.359005 µs ( 2.5%)
   Execution time upper quantile : 18.568355 µs (97.5%)
                   Overhead used : 8.595392 ns


lein test sci.test-utils

Ran 22 tests containing 120 assertions.
0 failures, 0 errors.
Running CLJS test in Node with optimizations :none
WARNING: Use of undeclared Var cljs.tools.reader.impl.utils/whitespace? at line 390 /home/user/Desktop/src/sci.sogaiu/inlined/sci/impl/toolsreader/v1v3v2/cljs/tools/reader.cljs
WARNING: Use of undeclared Var cljs.tools.reader.impl.utils/whitespace? at line 857 /home/user/Desktop/src/sci.sogaiu/inlined/sci/impl/toolsreader/v1v3v2/cljs/tools/reader.cljs
WARNING: Use of undeclared Var cljs.tools.reader.impl.utils/whitespace? at line 945 /home/user/Desktop/src/sci.sogaiu/inlined/sci/impl/toolsreader/v1v3v2/cljs/tools/reader.cljs
WARNING: Use of undeclared Var cljs.tools.reader.impl.utils/whitespace? at line 951 /home/user/Desktop/src/sci.sogaiu/inlined/sci/impl/toolsreader/v1v3v2/cljs/tools/reader.cljs

Testing sci.core-test

Testing sci.impl.parser-test

Ran 21 tests containing 120 assertions.
0 failures, 0 errors.
Running CLJS test in Node with optimizations :advanced
WARNING: Use of undeclared Var cljs.tools.reader.impl.utils/whitespace? at line 390 /home/user/Desktop/src/sci.sogaiu/inlined/sci/impl/toolsreader/v1v3v2/cljs/tools/reader.cljs
WARNING: Use of undeclared Var cljs.tools.reader.impl.utils/whitespace? at line 857 /home/user/Desktop/src/sci.sogaiu/inlined/sci/impl/toolsreader/v1v3v2/cljs/tools/reader.cljs
WARNING: Use of undeclared Var cljs.tools.reader.impl.utils/whitespace? at line 945 /home/user/Desktop/src/sci.sogaiu/inlined/sci/impl/toolsreader/v1v3v2/cljs/tools/reader.cljs
WARNING: Use of undeclared Var cljs.tools.reader.impl.utils/whitespace? at line 951 /home/user/Desktop/src/sci.sogaiu/inlined/sci/impl/toolsreader/v1v3v2/cljs/tools/reader.cljs

Testing sci.core-test

Testing sci.impl.parser-test

Ran 21 tests containing 120 assertions.
0 failures, 0 errors.
Compiling binary for native test
Compiling sci.core
Compiling sci.impl.destructure
Compiling sci.impl.fns
Compiling sci.impl.functions
Compiling sci.impl.interpreter
Compiling sci.impl.macros
Compiling sci.impl.main
Compiling sci.impl.max-or-throw
Compiling sci.impl.parser
Compiling sci.impl.readers
Compiling sci.impl.toolsreader.v1v3v2.cljs.tools.reader.reader-types
Compiling sci.impl.toolsreader.v1v3v2.clojure.tools.reader
Compiling sci.impl.toolsreader.v1v3v2.clojure.tools.reader.default-data-readers
Compiling sci.impl.toolsreader.v1v3v2.clojure.tools.reader.edn
Compiling sci.impl.toolsreader.v1v3v2.clojure.tools.reader.impl.commons
Compiling sci.impl.toolsreader.v1v3v2.clojure.tools.reader.impl.errors
Compiling sci.impl.toolsreader.v1v3v2.clojure.tools.reader.impl.inspect
Compiling sci.impl.toolsreader.v1v3v2.clojure.tools.reader.impl.utils
Compiling sci.impl.toolsreader.v1v3v2.clojure.tools.reader.reader-types
Compiling sci.impl.utils
Created /home/user/Desktop/src/sci.sogaiu/target/sci-0.0.10-SNAPSHOT.jar
Created /home/user/Desktop/src/sci.sogaiu/target/sci-0.0.10-SNAPSHOT-standalone.jar
Executing [
/usr/lib/jvm/java-8-graal/jre/bin/java \
-XX:+UnlockExperimentalVMOptions \
-XX:+EnableJVMCI \
-Dtruffle.TrustAllTruffleRuntimeProviders=true \
-Dtruffle.TruffleRuntime=com.oracle.truffle.api.impl.DefaultTruffleRuntime \
-Dgraalvm.ForcePolyglotInvalid=true \
-Dgraalvm.locatorDisabled=true \
-d64 \
-XX:-UseJVMCIClassLoader \
-XX:+UseJVMCINativeLibrary \
-Xss10m \
-Xms1g \
-Xmx9856050784 \
-Duser.country=US \
-Duser.language=en \
-Dorg.graalvm.version=19.2.0 \
-Dorg.graalvm.config=CE \
-Dcom.oracle.graalvm.isaot=true \
-Djvmci.class.path.append=/usr/lib/jvm/java-8-graal/jre/lib/jvmci/graal.jar \
-Dclojure.spec.skip-macros=true \
-Dclojure.compiler.direct-linking=true \
-Xmx3g \
-Xbootclasspath/a:/usr/lib/jvm/java-8-graal/jre/lib/boot/graal-sdk.jar:/usr/lib/jvm/java-8-graal/jre/lib/boot/graaljs-scriptengine.jar \
-cp \
/usr/lib/jvm/java-8-graal/jre/lib/svm/builder/objectfile.jar:/usr/lib/jvm/java-8-graal/jre/lib/svm/builder/svm-llvm.jar:/usr/lib/jvm/java-8-graal/jre/lib/svm/builder/pointsto.jar:/usr/lib/jvm/java-8-graal/jre/lib/svm/builder/graal-llvm.jar:/usr/lib/jvm/java-8-graal/jre/lib/svm/builder/llvm-platform-specific.jar:/usr/lib/jvm/java-8-graal/jre/lib/svm/builder/javacpp.jar:/usr/lib/jvm/java-8-graal/jre/lib/svm/builder/svm.jar:/usr/lib/jvm/java-8-graal/jre/lib/svm/builder/llvm-wrapper.jar:/usr/lib/jvm/java-8-graal/jre/lib/jvmci/jvmci-api.jar:/usr/lib/jvm/java-8-graal/jre/lib/jvmci/jvmci-hotspot.jar:/usr/lib/jvm/java-8-graal/jre/lib/jvmci/graal-management.jar:/usr/lib/jvm/java-8-graal/jre/lib/jvmci/graal.jar \
com.oracle.svm.hosted.NativeImageGeneratorRunner \
-watchpid \
14779 \
-imagecp \
/usr/lib/jvm/java-8-graal/jre/lib/boot/graal-sdk.jar:/usr/lib/jvm/java-8-graal/jre/lib/boot/graaljs-scriptengine.jar:/usr/lib/jvm/java-8-graal/jre/lib/svm/builder/objectfile.jar:/usr/lib/jvm/java-8-graal/jre/lib/svm/builder/svm-llvm.jar:/usr/lib/jvm/java-8-graal/jre/lib/svm/builder/pointsto.jar:/usr/lib/jvm/java-8-graal/jre/lib/svm/builder/graal-llvm.jar:/usr/lib/jvm/java-8-graal/jre/lib/svm/builder/llvm-platform-specific.jar:/usr/lib/jvm/java-8-graal/jre/lib/svm/builder/javacpp.jar:/usr/lib/jvm/java-8-graal/jre/lib/svm/builder/svm.jar:/usr/lib/jvm/java-8-graal/jre/lib/svm/builder/llvm-wrapper.jar:/usr/lib/jvm/java-8-graal/jre/lib/jvmci/jvmci-api.jar:/usr/lib/jvm/java-8-graal/jre/lib/jvmci/jvmci-hotspot.jar:/usr/lib/jvm/java-8-graal/jre/lib/jvmci/graal-management.jar:/usr/lib/jvm/java-8-graal/jre/lib/jvmci/graal.jar:/usr/lib/jvm/java-8-graal/jre/lib/svm/library-support.jar:/home/user/Desktop/src/sci.sogaiu/target/sci-0.0.10-SNAPSHOT-standalone.jar \
-H:Path=/home/user/Desktop/src/sci.sogaiu \
-H:Class=sci.impl.main \
-H:+ReportExceptionStackTraces \
-H:IncludeResources=SCI_VERSION \
-H:ClassInitialization=java.lang.Math$RandomNumberGeneratorHolder:run_time \
-H:ClassInitialization=:build_time \
-H:Log=registerResource: \
-H:FallbackThreshold=0 \
-H:CLibraryPath=/usr/lib/jvm/java-8-graal/jre/lib/svm/clibraries/linux-amd64 \
-H:ReflectionConfigurationFiles=/home/user/Desktop/src/sci.sogaiu/reflection.json \
-H:Name=sci
]
[sci:14801]    classlist:   3,496.86 ms
[sci:14801]        (cap):   1,380.83 ms
[sci:14801]        setup:   2,937.58 ms
[Use -Dgraal.LogFile=<path> to redirect Graal log output to a file.]
[thread:26] scope: ForkJoinPool-4-worker-1
  [thread:26] scope: ForkJoinPool-4-worker-1.registerResource
  ResourcesFeature: registerResource: SCI_VERSION
[sci:14801]   (typeflow):   9,386.34 ms
[sci:14801]    (objects):   6,611.64 ms
[sci:14801]   (features):     452.19 ms
[sci:14801]     analysis:  16,978.19 ms
[sci:14801]     (clinit):     244.77 ms
[sci:14801]     universe:     734.42 ms
[sci:14801]      (parse):   1,210.93 ms
[sci:14801]     (inline):   3,127.27 ms
[sci:14801]    (compile):  14,807.71 ms
[sci:14801]      compile:  20,115.27 ms
[sci:14801]        image:   1,520.54 ms
[sci:14801]        write:     389.65 ms
[sci:14801]      [total]:  46,393.98 ms
Running native test
Testing native version.
Testing native version.

lein test sci.core-test

lein test sci.impl.parser-test

lein test sci.performance
Testing reusable function result.
Evaluation count : 66990 in 6 samples of 11165 calls.
             Execution time mean : 10.732581 µs
    Execution time std-deviation : 1.183401 µs
   Execution time lower quantile : 9.303213 µs ( 2.5%)
   Execution time upper quantile : 12.342380 µs (97.5%)
                   Overhead used : 8.774518 ns


lein test sci.test-utils

Ran 22 tests containing 113 assertions.
0 failures, 0 errors.
```