### PR TITLE
Fix arity error

### DIFF
--- a/src/sci/impl/analyzer.cljc
+++ b/src/sci/impl/analyzer.cljc
@@ -1,4 +1,4 @@
-(ns sci.impl.macros
+(ns sci.impl.analyzer
   {:no-doc true}
   (:refer-clojure :exclude [destructure macroexpand macroexpand-all macroexpand-1])
   (:require

--- a/src/sci/impl/fns.cljc
+++ b/src/sci/impl/fns.cljc
@@ -4,12 +4,12 @@
 
 (defn parse-fn-args+body
   [interpret ctx
-   {:sci/keys [fixed-arity fixed-names var-arg-name destructure-vec _arg-list body] :as _m} macro?]
+   {:sci.impl/keys [fixed-arity fixed-names var-arg-name destructure-vec _arg-list body] :as _m} _macro?]
   (let [;; _ (prn macro?)
         min-var-args-arity (when var-arg-name fixed-arity)
         m (if min-var-args-arity
-            {:sci/min-var-args-arity min-var-args-arity}
-            {:sci/fixed-arity fixed-arity})]
+            {:sci.impl/min-var-args-arity min-var-args-arity}
+            {:sci.impl/fixed-arity fixed-arity})]
     (with-meta
       (fn [& args]
         (let [runtime-bindings (vec (interleave fixed-names (take fixed-arity args)))
@@ -27,13 +27,13 @@
 
 (defn lookup-by-arity [arities arity]
   (some (fn [f]
-          (let [{:keys [:sci/fixed-arity :sci/min-var-args-arity]} (meta f)]
+          (let [{:sci.impl/keys [fixed-arity min-var-args-arity]} (meta f)]
             (when (or (= arity fixed-arity )
                       (and min-var-args-arity
                            (>= arity min-var-args-arity)))
               f))) arities))
 
-(defn eval-fn [ctx interpret {:sci/keys [fn-bodies fn-name] :as f}]
+(defn eval-fn [ctx interpret {:sci.impl/keys [fn-bodies fn-name] :as f}]
   (let [macro? (:sci/macro f)
         self-ref (atom nil)
         call-self (fn [& args]

--- a/src/sci/impl/interpreter.cljc
+++ b/src/sci/impl/interpreter.cljc
@@ -3,11 +3,11 @@
   (:refer-clojure :exclude [destructure macroexpand])
   (:require
    [clojure.string :as str]
+   [sci.impl.exceptions :refer [exception-bindings]]
    [sci.impl.fns :as fns]
    [sci.impl.macros :as macros]
    [sci.impl.max-or-throw :refer [max-or-throw]]
    [sci.impl.namespaces :as namespaces]
-   [sci.impl.exceptions :refer [exception-bindings]]
    [sci.impl.parser :as p]
    [sci.impl.utils :as utils :refer [throw-error-with-location
                                      rethrow-with-location-of-node
@@ -85,7 +85,6 @@
   [ctx [_def var-name ?docstring ?init]]
   (let [docstring (when ?init ?docstring)
         init (if docstring ?init ?docstring)
-        ;; _ (prn "init" (meta init))
         init (interpret ctx init)
         m (if docstring {:sci/doc docstring} {})
         var-name (with-meta var-name m)]
@@ -97,13 +96,7 @@
    (find bindings sym)
    (when (some-> sym meta :sci.impl/var.declared)
      (find @env sym))
-   (find classes sym)
-   ;; (find namespaces/clojure-core sym)
-   #_(when-let [ns (namespace sym)]
-       (when (or (= "clojure.core" ns)
-                 (= "cljs.core" ns))
-         (find namespaces/clojure-core (symbol (name sym)))))
-   ))
+   (find classes sym)))
 
 (defn resolve-symbol [ctx expr]
   (second
@@ -306,7 +299,7 @@
           (not eval?) (do nil ;; (prn "not eval" expr)
                           expr)
           (:sci.impl/try expr) (eval-try ctx expr)
-          (:sci/fn expr) (fns/eval-fn ctx interpret expr)
+          (:sci.impl/fn expr) (fns/eval-fn ctx interpret expr)
           (:sci.impl/eval-call m) (eval-call ctx expr)
           (symbol? expr) (resolve-symbol ctx expr)
           (map? expr) (zipmap (map #(interpret ctx %) (keys expr))

--- a/src/sci/impl/interpreter.cljc
+++ b/src/sci/impl/interpreter.cljc
@@ -10,7 +10,7 @@
    [sci.impl.exceptions :refer [exception-bindings]]
    [sci.impl.parser :as p]
    [sci.impl.utils :as utils :refer [throw-error-with-location
-                                     re-throw-with-location-of-node
+                                     rethrow-with-location-of-node
                                      strip-core-ns]]))
 
 (declare interpret)
@@ -63,7 +63,7 @@
       (let [expr (macros/macroexpand ctx expr)
             ret (try (interpret ctx expr)
                      (catch #?(:clj Exception :cljs js/Error) e
-                       (utils/re-throw-with-location-of-node e expr)))]
+                       (utils/rethrow-with-location-of-node e expr)))]
         (if-let [n (next exprs)]
           (recur n)
           ret)))))
@@ -295,7 +295,7 @@
                        (throw (new #?(:clj Exception :cljs js/Error)
                                    (str "Cannot call " (pr-str f) " as a function."))))))))
        (catch #?(:clj Exception :cljs js/Error) e
-         (re-throw-with-location-of-node e expr))))
+         (rethrow-with-location-of-node e expr))))
 
 (defn interpret
   [ctx expr]

--- a/src/sci/impl/interpreter.cljc
+++ b/src/sci/impl/interpreter.cljc
@@ -5,7 +5,7 @@
    [clojure.string :as str]
    [sci.impl.exceptions :refer [exception-bindings]]
    [sci.impl.fns :as fns]
-   [sci.impl.macros :as macros]
+   [sci.impl.analyzer :as ana]
    [sci.impl.max-or-throw :refer [max-or-throw]]
    [sci.impl.namespaces :as namespaces]
    [sci.impl.parser :as p]
@@ -60,7 +60,7 @@
   [ctx expr]
   (loop [exprs (rest expr)]
     (when-let [expr (first exprs)]
-      (let [expr (macros/macroexpand ctx expr)
+      (let [expr (ana/macroexpand ctx expr)
             ret (try (interpret ctx expr)
                      (catch #?(:clj Exception :cljs js/Error) e
                        (utils/rethrow-with-location-of-node e expr)))]

--- a/src/sci/impl/macros.cljc
+++ b/src/sci/impl/macros.cljc
@@ -9,7 +9,7 @@
    [sci.impl.for-macro :refer [expand-for]]
    [sci.impl.utils :refer
     [gensym* mark-resolve-sym mark-eval mark-eval-call constant?
-     re-throw-with-location-of-node throw-error-with-location
+     rethrow-with-location-of-node throw-error-with-location
      merge-meta kw-identical? strip-core-ns]]))
 
 (def macros '#{do if when and or -> ->> as-> quote quote* syntax-quote let fn
@@ -384,7 +384,7 @@
                          expanded)
                        (mark-eval-call (doall (map #(macroexpand ctx %) expr))))
                      (catch #?(:clj Exception :cljs js/Error) e
-                       (re-throw-with-location-of-node e expr)))
+                       (rethrow-with-location-of-node e expr)))
                 (mark-eval-call (doall (map #(macroexpand ctx %) expr))))))
           (let [ret (mark-eval-call (doall (map #(macroexpand ctx %) expr)))]
             ret)))))

--- a/src/sci/impl/macros.cljc
+++ b/src/sci/impl/macros.cljc
@@ -107,14 +107,14 @@
         arg-list (if var-arg
                    (conj fixed-names '& var-arg-name)
                    fixed-names)]
-    {:sci/arg-list arg-list
-     :sci/body [body-form]
-     :sci/fixed-arity fixed-arity
-     :sci/destructure-vec destructure-vec
-     :sci/fixed-names fixed-names
-     :sci/fixed-args fixed-args
-     :sci/var-arg-name var-arg-name
-     :sci/fn-name fn-name}))
+    #:sci.impl{:arg-list arg-list
+               :body [body-form]
+               :fixed-arity fixed-arity
+               :destructure-vec destructure-vec
+               :fixed-names fixed-names
+               :fixed-args fixed-args
+               :var-arg-name var-arg-name
+               :fn-name fn-name}))
 
 (defn expand-fn [ctx [_fn name? & body] macro?]
   (let [fn-name (if (symbol? name?)
@@ -131,21 +131,21 @@
                 ctx)
         arities (doall (map #(expand-fn-args+body ctx fn-name % macro?) bodies))]
     (mark-eval
-     {:sci/fn-bodies arities
-      :sci/fn-name fn-name
-      :sci/fn true})))
+     #:sci.impl{:fn-bodies arities
+                :fn-name fn-name
+                :fn true})))
 
 (defn expand-fn-literal-body [ctx expr]
-  (let [fn-body (get-in expr [:sci/fn-bodies 0])
-        fixed-names (:sci/fixed-names fn-body)
-        var-arg-name (:sci/var-arg-name fn-body)
+  (let [fn-body (get-in expr [:sci.impl/fn-bodies 0])
+        fixed-names (:sci.impl/fixed-names fn-body)
+        var-arg-name (:sci.impl/var-arg-name fn-body)
         bindings (if var-arg-name
                    (conj fixed-names var-arg-name)
                    fixed-names)
         bindings (zipmap bindings (repeat nil))
         ctx (update ctx :bindings merge bindings)]
     ;; expr
-    (-> (update-in expr [:sci/fn-bodies 0 :sci/body 0]
+    (-> (update-in expr [:sci.impl/fn-bodies 0 :sci.impl/body 0]
                    (fn [expr]
                      (macroexpand ctx expr)))
         mark-eval)))
@@ -229,7 +229,7 @@
         fn-body (list* 'fn #_fn-name body)
         f (expand-fn ctx fn-body macro?)
         f (assoc f :sci/macro macro?
-                   :sci/fn-name fn-name)]
+                 :sci.impl/fn-name fn-name)]
     (mark-eval-call (list 'def fn-name f))))
 
 (defn expand-comment
@@ -402,8 +402,7 @@
                   (merge-meta
                    (cond
                      ;; already expanded by reader
-                     (:sci/fn expr) (expand-fn-literal-body ctx expr)
-
+                     (:sci.impl/fn expr) (expand-fn-literal-body ctx expr)
                      (map? expr)
                      (-> (zipmap (map #(macroexpand ctx %) (keys expr))
                                  (map #(macroexpand ctx %) (vals expr)))

--- a/src/sci/impl/macros.cljc
+++ b/src/sci/impl/macros.cljc
@@ -228,7 +228,8 @@
         body (if docstring body (cons docstring? body))
         fn-body (list* 'fn #_fn-name body)
         f (expand-fn ctx fn-body macro?)
-        f (assoc f :sci/macro macro?)]
+        f (assoc f :sci/macro macro?
+                   :sci/fn-name fn-name)]
     (mark-eval-call (list 'def fn-name f))))
 
 (defn expand-comment

--- a/src/sci/impl/readers.cljc
+++ b/src/sci/impl/readers.cljc
@@ -31,16 +31,16 @@
         destructure-vec (if var-args?
                           (conj destructure-vec var-args-sym var-args-sym)
                           destructure-vec)
-        form {:sci/fn true
-              :sci/fn-bodies
-              [{:sci/binding-vector arg-list
-                ;; body gets macroexpanded after read phase
-                :sci/body [expr]
-                :sci/fixed-arity (count fixed-names)
-                :sci/destructure-vec destructure-vec
-                :sci/arg-list arg-list
-                :sci/fixed-names fixed-names
-                :sci/var-arg-name (when var-args? '%&)}]}]
+        form #:sci.impl{:fn true
+                        :fn-bodies
+                        [#:sci.impl{:binding-vector arg-list
+                                    ;; body gets macroexpanded after read phase
+                                    :body [expr]
+                                    :fixed-arity (count fixed-names)
+                                    :destructure-vec destructure-vec
+                                    :arg-list arg-list
+                                    :fixed-names fixed-names
+                                    :var-arg-name (when var-args? '%&)}]}]
     form))
 
 ;;;; Scratch

--- a/src/sci/impl/utils.cljc
+++ b/src/sci/impl/utils.cljc
@@ -52,7 +52,7 @@
                                  :row row
                                  :col col} data))))))
 
-(defn re-throw-with-location-of-node [^Exception e node]
+(defn rethrow-with-location-of-node [^Exception e node]
   (if-let [m #?(:clj (.getMessage e)
                 :cljs (.-message e))]
     (if (str/includes? m "[at line")

--- a/src/sci/impl/utils.cljc
+++ b/src/sci/impl/utils.cljc
@@ -54,18 +54,16 @@
 
 (defn re-throw-with-location-of-node [^Exception e node]
   (if-let [m #?(:clj (.getMessage e)
-             :cljs (.-message e))]
+                :cljs (.-message e))]
     (if (str/includes? m "[at line")
       (throw e)
       (let [{:keys [:row :col]} (meta node)]
         (if (and row col)
           (let [m (str m " [at line " row ", column " col "]")
-                new-exception (if-let [d (ex-data e)]
+                new-exception (let [d (ex-data e)]
                                 (ex-info m (merge {:type :sci/error
                                                    :row row
-                                                   :col col} d))
-                                #?(:clj (Exception. m e)
-                                   :cljs (do (set! (.-message e) m) e)))]
+                                                   :col col} d) e))]
             (throw new-exception))
           (throw e))))
     (throw e)))

--- a/src/sci/impl/utils.cljc
+++ b/src/sci/impl/utils.cljc
@@ -63,7 +63,8 @@
                 new-exception (let [d (ex-data e)]
                                 (ex-info m (merge {:type :sci/error
                                                    :row row
-                                                   :col col} d) e))]
+                                                   :col col
+                                                   :message m} d) e))]
             (throw new-exception))
           (throw e))))
     (throw e)))

--- a/test/sci/core_test.cljc
+++ b/test/sci/core_test.cljc
@@ -268,17 +268,25 @@
                         (tu/eval* "(+ 1 2 3 4) (vec (range))" {:realize-max 100})))
   (is (thrown-with-msg? #?(:clj Exception :cljs js/Error)
                         #"\[at line 1, column 19\]"
-                        (tu/eval* "(+ 1 2 3 4 5) (do x)" {})))
+                        (eval* "(+ 1 2 3 4 5) (do x)")))
   (is (thrown-with-msg?
        #?(:clj Exception :cljs js/Error)
-       #"Wrong number of arguments. Expected: 0, got: 1, \(1\) \[at line 1, column 15\]"
-       (tu/eval* "(defn foo []) (foo 1)" {})))
+       #"Wrong number of arguments. Expected: 0, got: 1"
+       (eval* "(defn foo []) (foo 1)")))
   (is (thrown-with-msg?
        #?(:clj Exception :cljs js/Error)
-       #"Wrong number of arguments. Expected: 1, got: 0, \(\(bindings\) \{x 1\}\) \[at line 1, column 93\]"
-       (tu/eval* (str "(defmacro bindings [a] (zipmap (mapv #(list 'quote %) (keys &env)) (keys &env))) "
-                      "(let [x 1] (bindings))")
-                 {}))))
+       #"Wrong number of arguments. Expected at least: 1, got: 0"
+       (eval* "(defn foo [x & xs]) (foo)")))
+  (is (thrown-with-msg?
+       #?(:clj Exception :cljs js/Error)
+       #"Wrong number of arguments. Expected: 1, got: 0"
+       (eval* (str "(defmacro bindings [a] (zipmap (mapv #(list 'quote %) (keys &env)) (keys &env))) "
+                   "(let [x 1] (bindings))"))))
+  (is (thrown-with-msg?
+       #?(:clj Exception :cljs js/Error)
+       #"Wrong number of arguments. Expected at least: 1, got: 0"
+       (eval* (str "(defmacro foo [x & xs]) "
+                   "(foo)")))))
 
 (deftest macro-test
   (when-not tu/native?

--- a/test/sci/core_test.cljc
+++ b/test/sci/core_test.cljc
@@ -414,10 +414,14 @@
                            {:bindings {'state state
                                        'reset! reset!}})))
       (is (= :finally @state))))
-  #?@(:clj [(is (nil? (eval* "(try (mapv 1 [1 2 3]) (catch Exception e nil))")))
-            (is (= {:a 1} (eval* "(try (throw (ex-info \"\" {:a 1})) (catch Exception e (ex-data e)))")))]
-      :cljs [(is (nil? (eval* "(try (mapv 1 [1 2 3]) (catch js/Error e nil))")))
-             (is (= {:a 1} (eval* "(try (throw (ex-info \"\" {:a 1})) (catch js/Error e (ex-data e)))")))])
+  #?@(:clj
+      [(is (nil? (eval* "(try (mapv 1 [1 2 3]) (catch Exception e nil))")))
+       (is (= {:type :sci/error, :row 1, :col 6, :a 1}
+              (eval* "(try (throw (ex-info \"\" {:a 1})) (catch Exception e (ex-data e)))")))]
+      :cljs
+      [(is (nil? (eval* "(try (mapv 1 [1 2 3]) (catch js/Error e nil))")))
+       (is (= {:type :sci/error, :row 1, :col 6, :a 1}
+              (eval* "(try (throw (ex-info \"\" {:a 1})) (catch js/Error e (ex-data e)))")))])
   (is (thrown-with-msg? #?(:clj Exception :cljs js/Error) #"Foo"
                         (eval* "(try 1 (catch Foo e e))"))))
 

--- a/test/sci/core_test.cljc
+++ b/test/sci/core_test.cljc
@@ -269,32 +269,34 @@
   (is (thrown-with-msg? #?(:clj Exception :cljs js/Error)
                         #"\[at line 1, column 19\]"
                         (eval* "(+ 1 2 3 4 5) (do x)")))
-  (tu/assert-submap {:type :sci/error, :row 1, :col 15,
-                     :message #"Cannot call foo with 1 arguments \[at line 1, column 15\]"}
-                    (try (eval* "(defn foo []) (foo 1)")
-                         (catch #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo) ex
-                           (let [d (ex-data ex)]
-                             d))))
-  (tu/assert-submap {:type :sci/error, :row 1, :col 21,
-                     :message #"Cannot call foo with 0 arguments"}
-                    (try (eval* "(defn foo [x & xs]) (foo)")
-                         (catch #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo) ex
-                           (let [d (ex-data ex)]
-                             d))))
-  (tu/assert-submap {:type :sci/error, :row 1, :col 93,
-                     :message #"Cannot call bindings"}
-                    (try (eval* (str "(defmacro bindings [a] (zipmap (mapv #(list 'quote %) (keys &env)) (keys &env))) "
-                                     "(let [x 1] (bindings))"))
-                         (catch #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo) ex
-                           (let [d (ex-data ex)]
-                             d))))
-  (tu/assert-submap {:type :sci/error, :row 1, :col 25,
-                     :message #"Cannot call foo"}
-                    (try (eval* (str "(defmacro foo [x & xs]) "
-                                     "(foo)"))
-                         (catch #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo) ex
-                           (let [d (ex-data ex)]
-                             d)))))
+  (when-not tu/native?
+    (testing "ex-data"
+      (tu/assert-submap {:type :sci/error, :row 1, :col 15,
+                         :message #"Cannot call foo with 1 arguments \[at line 1, column 15\]"}
+                        (try (eval* "(defn foo []) (foo 1)")
+                             (catch #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo) ex
+                               (let [d (ex-data ex)]
+                                 d))))
+      (tu/assert-submap {:type :sci/error, :row 1, :col 21,
+                         :message #"Cannot call foo with 0 arguments"}
+                        (try (eval* "(defn foo [x & xs]) (foo)")
+                             (catch #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo) ex
+                               (let [d (ex-data ex)]
+                                 d))))
+      (tu/assert-submap {:type :sci/error, :row 1, :col 93,
+                         :message #"Cannot call bindings"}
+                        (try (eval* (str "(defmacro bindings [a] (zipmap (mapv #(list 'quote %) (keys &env)) (keys &env))) "
+                                         "(let [x 1] (bindings))"))
+                             (catch #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo) ex
+                               (let [d (ex-data ex)]
+                                 d))))
+      (tu/assert-submap {:type :sci/error, :row 1, :col 25,
+                         :message #"Cannot call foo"}
+                        (try (eval* (str "(defmacro foo [x & xs]) "
+                                         "(foo)"))
+                             (catch #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo) ex
+                               (let [d (ex-data ex)]
+                                 d)))))))
 
 (deftest macro-test
   (when-not tu/native?

--- a/test/sci/core_test.cljc
+++ b/test/sci/core_test.cljc
@@ -268,7 +268,17 @@
                         (tu/eval* "(+ 1 2 3 4) (vec (range))" {:realize-max 100})))
   (is (thrown-with-msg? #?(:clj Exception :cljs js/Error)
                         #"\[at line 1, column 19\]"
-                        (tu/eval* "(+ 1 2 3 4 5) (do x)" {}))))
+                        (tu/eval* "(+ 1 2 3 4 5) (do x)" {})))
+  (is (thrown-with-msg?
+       #?(:clj Exception :cljs js/Error)
+       #"Wrong number of arguments. Expected: 0, got: 1, \(1\) \[at line 1, column 15\]"
+       (tu/eval* "(defn foo []) (foo 1)" {})))
+  (is (thrown-with-msg?
+       #?(:clj Exception :cljs js/Error)
+       #"Wrong number of arguments. Expected: 1, got: 0, \(\(bindings\) \{x 1\}\) \[at line 1, column 93\]"
+       (tu/eval* (str "(defmacro bindings [a] (zipmap (mapv #(list 'quote %) (keys &env)) (keys &env))) "
+                      "(let [x 1] (bindings))")
+                 {}))))
 
 (deftest macro-test
   (when-not tu/native?

--- a/test/sci/impl/parser_test.cljc
+++ b/test/sci/impl/parser_test.cljc
@@ -21,7 +21,7 @@
   (is (= '(defn foo []) (p/parse-string "(defn foo [])")))
   (let [foo-sym (second (p/parse-string "(defn foo [])"))]
     (is (= {:row 1 :col 7} (meta foo-sym))))
-  (is (:sci/fn (p/parse-string "#(inc 1 2 %)")))
+  (is (:sci.impl/fn (p/parse-string "#(inc 1 2 %)")))
   (is (re-find (p/parse-string "#\"foo\"") "foo"))
   (is (= '(do (+ 1 2 3)) (p/parse-string "(do (+ 1 2 3)\n)")))
   (is (= [1 2] (p/parse-string-all "#_(+ 1 2 3) 1 2"))))

--- a/test/sci/test_utils.cljc
+++ b/test/sci/test_utils.cljc
@@ -1,7 +1,8 @@
 (ns sci.test-utils
   (:require [sci.core :refer [eval-string]]
             #?(:clj [me.raynes.conch :refer [let-programs] :as sh])
-            #?(:clj [clojure.edn :as edn])))
+            #?(:clj [clojure.edn :as edn])
+            [clojure.test :refer [is]]))
 
 (def native? #?(:clj (= "native" (System/getenv "SCI_TEST_ENV"))
                 :cljs false))
@@ -19,6 +20,38 @@
                 (throw (ex-info (:stderr (ex-data e))
                                 (ex-data e))))))
        :cljs nil)))
+
+(defn submap?
+  "Is m1 a subset of m2? Taken from
+  https://github.com/clojure/spec-alpha2, clojure.test-clojure.spec"
+  [m1 m2]
+  (cond
+    (and (map? m1) (map? m2))
+    (every? (fn [[k v]] (and (contains? m2 k)
+                             (submap? v (get m2 k))))
+            m1)
+    (instance? java.util.regex.Pattern m1)
+    (re-find m1 m2)
+    :else (= m1 m2)))
+
+(defmacro assert-submap [m r]
+  `(is (submap? ~m ~r)))
+
+(defmacro assert-some-submap [m r]
+  `(is (some #(submap? ~m %) ~r)))
+
+(defmacro assert-submaps
+  "Asserts that maps are submaps of result in corresponding order and
+  that the number of maps corresponds to the number of
+  results. Returns true if all assertions passed (useful for REPL)."
+  [maps result]
+  `(let [maps# ~maps
+         res# ~result]
+     (and
+      (is (= (count maps#) (count res#)))
+      (every? identity
+              (for [[m# r#] (map vector maps# res#)]
+                (assert-submap m# r#))))))
 
 ;;;; Scratch
 


### PR DESCRIPTION
Also included is the renaming of `re-throw-with-location-of-node` to `rethrow-with-location-of-node` that came up.

One of the existing tests was also adjusted as `rethrow-with-location-of-node` is used to add more info.