### PR TITLE
Add `some->` macro

### DIFF
--- a/src/sci/impl/namespaces.cljc
+++ b/src/sci/impl/namespaces.cljc
@@ -91,6 +91,17 @@
        (let [~x (first xs#)]
          ~@body))))
 
+(defn some->*
+  [_&form _&env expr & forms]
+  (let [g (gensym)
+        steps (map (fn [step] `(if (nil? ~g) nil (-> ~g ~step)))
+                   forms)]
+    `(let [~g ~expr
+           ~@(interleave (repeat g) (butlast steps))]
+       ~(if (empty? steps)
+          g
+          (last steps)))))
+
 (def ex-message
   (if-let [v (resolve 'clojure.core/ex-message)]
     @v
@@ -332,6 +343,7 @@
    'simple-keyword? simple-keyword?
    'simple-symbol? simple-symbol?
    'some? some?
+   'some-> (macrofy some->*)
    'string? string?
    'str str
    'second second

--- a/test/sci/core_test.cljc
+++ b/test/sci/core_test.cljc
@@ -57,6 +57,9 @@
   (testing "as->"
     (is (= "4444444444"
            (eval* '(as-> 1 x (inc x) (inc x) (inc x) (apply str (repeat 10 (str x))))))))
+  (testing "some->"
+    (is (= nil   (eval* '(some-> {:a {:a nil}}        :a :a :a (clojure.string/lower-case)))))
+    (is (= "aaa" (eval* '(some-> {:a {:a {:a "AAA"}}} :a :a :a (clojure.string/lower-case))))))
   (testing "literals"
     (is (= {:a 4
             :b {:a 2}


### PR DESCRIPTION
Herewith adding the `some->` macro. Seems to work in tests. 

Compiling it with babashka didn't give the expected result. Not sure if there is something wrong with my setup. 

```
/bb -e '(some-> {:a 1} :a)'
nil
```