### PR TITLE
unshadow local var method

### DIFF
--- a/src/sci/impl/interop.cljc
+++ b/src/sci/impl/interop.cljc
@@ -9,11 +9,11 @@
 #?(:clj (set! *warn-on-reflection* true))
 
 (defn invoke-instance-method
-  #?@(:cljs [[obj _target-class method args]
+  #?@(:cljs [[obj _target-class method-name args]
              ;; gobj/get didn't work here
-             (if-let [method (aget obj method)]
+             (if-let [method (aget obj method-name)]
                (apply method obj args)
-               (throw (js/Error. "Could not find method" method)))]
+               (throw (js/Error. "Could not find method" method-name)))]
       :clj
       [#_([obj method args]
         (invoke-instance-method obj nil method args))


### PR DESCRIPTION
Error message was missing method name