### PR TITLE
Throw an error in case of wrong number of arguments to if

### DIFF
--- a/src/sci/impl/analyzer.cljc
+++ b/src/sci/impl/analyzer.cljc
@@ -339,6 +339,13 @@
                     ;; expand-fn will take care of the analysis of the body
                     (list 'fn [] (cons 'do body)))))))
 
+(defn expand-if
+  [ctx [_if & exprs :as expr]]
+  (case (count exprs)
+    (0 1) (throw-error-with-location "Too few arguments to if" expr)
+    (2 3) (mark-eval-call `(~'if ~@(analyze-children ctx exprs)))
+    (throw-error-with-location "Too many arguments to if" expr)))
+
 (defn expand-case
   [ctx expr]
   (let [v (analyze ctx (second expr))
@@ -598,6 +605,7 @@
             doseq (analyze ctx (expand-doseq ctx expr))
             require (mark-eval-call
                      (cons 'require (analyze-children ctx (rest expr))))
+            if (expand-if ctx expr)
             case (expand-case ctx expr)
             try (expand-try ctx expr)
             declare (expand-declare ctx expr)

--- a/src/sci/impl/interpreter.cljc
+++ b/src/sci/impl/interpreter.cljc
@@ -92,10 +92,7 @@
         expr (rest expr)
         then (first expr)
         expr (rest expr)
-        else (first expr)
-        extra (next expr)]
-    (when extra
-      (throw (ex-info "Too many arguments to if" {:extra (rest expr)})))
+        else (first expr)]
     (if (interpret ctx cond)
       (interpret ctx then)
       (interpret ctx else))))

--- a/src/sci/impl/interpreter.cljc
+++ b/src/sci/impl/interpreter.cljc
@@ -92,7 +92,10 @@
         expr (rest expr)
         then (first expr)
         expr (rest expr)
-        else (first expr)]
+        else (first expr)
+        extra (next expr)]
+    (when extra
+      (throw (ex-info "Too many arguments to if" {:extra (rest expr)})))
     (if (interpret ctx cond)
       (interpret ctx then)
       (interpret ctx else))))

--- a/test/sci/core_test.cljc
+++ b/test/sci/core_test.cljc
@@ -23,8 +23,14 @@
   (testing "if and when"
     (is (= 1 (eval* 0 '(if (zero? *in*) 1 2))))
     (is (= 2 (eval* 1 '(if (zero? *in*) 1 2))))
+    (is (thrown-with-msg? #?(:clj Exception :cljs js/Error) #"Too few arguments to if" 
+                          (eval* '(if))))
+    (is (thrown-with-msg? #?(:clj Exception :cljs js/Error) #"Too few arguments to if" 
+                          (eval* '(if 1))))
     (is (thrown-with-msg? #?(:clj Exception :cljs js/Error) #"Too many arguments to if" 
                           (eval* '(if 1 2 3 4))))
+    (is (thrown-with-msg? #?(:clj Exception :cljs js/Error) #"Too many arguments to if" 
+                          (eval* '(if 1 2 3 4 5))))
     (is (= 1 (eval* 0 '(when (zero? *in*) 1))))
     (is (nil? (eval* 1 '(when (zero? *in*) 1))))
     (testing "when can have multiple body expressions"

--- a/test/sci/core_test.cljc
+++ b/test/sci/core_test.cljc
@@ -23,6 +23,8 @@
   (testing "if and when"
     (is (= 1 (eval* 0 '(if (zero? *in*) 1 2))))
     (is (= 2 (eval* 1 '(if (zero? *in*) 1 2))))
+    (is (thrown-with-msg? #?(:clj Exception :cljs js/Error) #"Too many arguments to if" 
+                          (eval* '(if 1 2 3 4))))
     (is (= 1 (eval* 0 '(when (zero? *in*) 1))))
     (is (nil? (eval* 1 '(when (zero? *in*) 1))))
     (testing "when can have multiple body expressions"


### PR DESCRIPTION
This adds a check to see if there are too many arguments to an `if` expression. It doesn't do anything for branches that are not walked.

Error message copied from Clojure:
```
=> (if 1 2 3 4)

             java.lang.RuntimeException: Too many arguments to if
clojure.lang.Compiler$CompilerException: Syntax error compiling if at (1:1).
```