### PR TITLE
Failures for CLJS like interop

### DIFF
--- a/src/sci/impl/interop.cljc
+++ b/src/sci/impl/interop.cljc
@@ -32,7 +32,7 @@
      (Reflector/invokeStaticMethod class (str method-name) (object-array args))
      :cljs (if-let [method (gobj/get class method-name)]
              (apply method args)
-             (throw (js/Error. "Could not find method" method-name)))))
+             (throw (js/Error. (str "Could not find method " method-name))))))
 
 (defn get-static-field #?(:clj [[^Class class field-name-sym]]
                           :cljs [_])

--- a/src/sci/impl/interop.cljc
+++ b/src/sci/impl/interop.cljc
@@ -16,7 +16,7 @@
                (aget obj (subs method-name 1))
                (if-let [method (aget obj method-name)]
                  (apply method obj args)
-                 (throw (js/Error. (str "Could not find method: " method-name)))))]
+                 (throw (js/Error. (str "Could not find instance method: " method-name)))))]
       :clj
       [#_([obj method args]
         (invoke-instance-method obj nil method args))
@@ -32,7 +32,7 @@
      (Reflector/invokeStaticMethod class (str method-name) (object-array args))
      :cljs (if-let [method (gobj/get class method-name)]
              (apply method args)
-             (throw (js/Error. (str "Could not find method " method-name))))))
+             (throw (js/Error. (str "Could not find static method " method-name))))))
 
 (defn get-static-field #?(:clj [[^Class class field-name-sym]]
                           :cljs [[class field-name-sym]])

--- a/src/sci/impl/interop.cljc
+++ b/src/sci/impl/interop.cljc
@@ -35,9 +35,9 @@
              (throw (js/Error. (str "Could not find method " method-name))))))
 
 (defn get-static-field #?(:clj [[^Class class field-name-sym]]
-                          :cljs [_])
+                          :cljs [[class field-name-sym]])
   #?(:clj (Reflector/getStaticField class (str field-name-sym))
-     :cljs (throw (js/Error. "Not implemented yet."))))
+     :cljs (aget class (str field-name-sym))))
 
 (defn invoke-constructor #?(:clj [^Class class args]
                             :cljs [constructor args])

--- a/src/sci/impl/interop.cljc
+++ b/src/sci/impl/interop.cljc
@@ -50,7 +50,7 @@
 (defn get-static-field #?(:clj [[^Class class field-name-sym]]
                           :cljs [[class field-name-sym]])
   #?(:clj (Reflector/getStaticField class (str field-name-sym))
-     :cljs (aget class (str field-name-sym))))
+     :cljs (gobj/get class field-name-sym)))
 
 (defn invoke-constructor #?(:clj [^Class class args]
                             :cljs [constructor args])

--- a/test/sci/interop_test.cljc
+++ b/test/sci/interop_test.cljc
@@ -56,8 +56,10 @@
 
 #?(:cljs
    (deftest methods-on-static-fields
-     (is (= 42 (tu/eval* "(.log js/console \"42\")" {:classes {'js js/global}})))
-     (is (= 42 (tu/eval* "(js/console.log \"42\")"  {:classes {'js js/global}})))))
+     (is (= 42 (tu/eval* "(do (.log js/console \"42\") 42)" {:classes {:allow :all
+                                                                       'js js/global}})))
+     (is (= 42 (tu/eval* "(do (js/console.log \"42\") 42)" {:classes {:allow :all
+                                                                      'js js/global}})))))
 
 #?(:cljs
    (do (def fs (let [m (js->clj (js/require "fs"))]

--- a/test/sci/interop_test.cljc
+++ b/test/sci/interop_test.cljc
@@ -62,6 +62,11 @@
                                                                       'js js/global}})))))
 
 #?(:cljs
+   (deftest static-field-constructors
+     (is (= 42 (tu/eval* "(js/parseInt (.-message (js/Error. \"42\")))" {:classes {:allow :all
+                                                                                   'js js/global}})))))
+
+#?(:cljs
    (do (def fs (let [m (js->clj (js/require "fs"))]
                  (zipmap (map symbol (keys m)) (vals m))))
        (deftest add-object-as-namespace

--- a/test/sci/interop_test.cljc
+++ b/test/sci/interop_test.cljc
@@ -51,7 +51,8 @@
 
 #?(:cljs
    (deftest static-methods
-     (is (= \C (tu/eval* "(String/fromCharCode 67)" {:classes {'String js/String}})))))
+     (is (= \C (tu/eval* "(String/fromCharCode 67)" {:classes {'String js/String}})))
+     (is (= 42 (tu/eval* "(js/parseInt \"42\")"     {:classes {'js js/global}})))))
 
 #?(:cljs
    (do (def fs (let [m (js->clj (js/require "fs"))]

--- a/test/sci/interop_test.cljc
+++ b/test/sci/interop_test.cljc
@@ -55,6 +55,11 @@
      (is (= 42 (tu/eval* "(js/parseInt \"42\")"     {:classes {'js js/global}})))))
 
 #?(:cljs
+   (deftest methods-on-static-fields
+     (is (= 42 (tu/eval* "(.log js/console \"42\")" {:classes {'js js/global}})))
+     (is (= 42 (tu/eval* "(js/console.log \"42\")"  {:classes {'js js/global}})))))
+
+#?(:cljs
    (do (def fs (let [m (js->clj (js/require "fs"))]
                  (zipmap (map symbol (keys m)) (vals m))))
        (deftest add-object-as-namespace


### PR DESCRIPTION
I've added one example in the tests to show that `js/global` can be used:
```
(tu/eval* "(js/parseInt \"42\")" {:classes {'js js/global}})
```

The above works, but when I try to go further I run into issues. The two examples below, that are valid in `cljs`, fail in Sci js code:
```clj
 (.log js/console "42")
 (js/console.log "42")
```




The errors are shown below. I have tried to implement [the missing functionality](https://github.com/borkdude/sci/blob/master/src/sci/impl/interop.cljc#L40), but no luck so far. I run in all kinds of weirds errors. I tried a js Proxy class and some other things, but all without success.

```
ERROR in (methods-on-static-fields) (Error:NaN:NaN)
expected: (= 42 (tu/eval* "(.log js/console \"42\")" {:classes {(quote js) js/global}}))
  actual: #error {:message "Not implemented yet. [at line 1, column 1]", :data {:type :sci/error, :line 1, :column 1, :message "Not implemented yet. [at line 1, column 1]"}, :cause #object[Error Error: Not implemented yet.]}

ERROR in (methods-on-static-fields) (Error:NaN:NaN)
expected: (= 42 (tu/eval* "(js/console.log \"42\")" {:classes {(quote js) js/global}}))
  actual: #error {:message "Could not find method [at line 1, column 1]", :data {:type :sci/error, :line 1, :column 1, :message "Could not find method [at line 1, column 1]"}, :cause #object[Error Error: Could not find method]}
```

