### PR TITLE
Fix (js/alert "hi") in browser

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,10 @@
  :deps {org.clojure/tools.reader {:mvn/version "1.3.2"}
         borkdude/edamame {:mvn/version "0.0.10"}
         borkdude/graal.locking {:mvn/version "0.0.2"}
-        borkdude/sci.impl.reflector {:mvn/version "0.0.1"}}
+        borkdude/sci.impl.reflector {:mvn/version "0.0.1"}
+        appliedscience/js-interop {:mvn/version "0.2.4"}
+      
+      }
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {org.clojure/clojure {:mvn/version "1.9.0"}

--- a/deps.edn
+++ b/deps.edn
@@ -2,9 +2,7 @@
  :deps {org.clojure/tools.reader {:mvn/version "1.3.2"}
         borkdude/edamame {:mvn/version "0.0.10"}
         borkdude/graal.locking {:mvn/version "0.0.2"}
-        borkdude/sci.impl.reflector {:mvn/version "0.0.1"}
-        appliedscience/js-interop {:mvn/version "0.2.4"}
-      
+        borkdude/sci.impl.reflector {:mvn/version "0.0.1"}      
       }
  :aliases
  {:test {:extra-paths ["test"]

--- a/deps.edn
+++ b/deps.edn
@@ -2,8 +2,7 @@
  :deps {org.clojure/tools.reader {:mvn/version "1.3.2"}
         borkdude/edamame {:mvn/version "0.0.10"}
         borkdude/graal.locking {:mvn/version "0.0.2"}
-        borkdude/sci.impl.reflector {:mvn/version "0.0.1"}      
-      }
+        borkdude/sci.impl.reflector {:mvn/version "0.0.1"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {org.clojure/clojure {:mvn/version "1.9.0"}

--- a/src/sci/impl/interop.cljc
+++ b/src/sci/impl/interop.cljc
@@ -34,10 +34,7 @@
   #?(:clj
      (Reflector/invokeStaticMethod class (str method-name) (object-array args))
      :cljs (if-let [method (gobj/get class method-name)]
-             ;; (js/alert "hi") doesn't work with apply
-             (if (= js/window class)
-               (.apply (gobj/get class method-name) class (to-array args))
-               (apply method args))
+             (.apply method class (to-array args))
              (let [method-name (str method-name)
                    [field sub-method-name] (clojure.string/split method-name #"\.")]
                (cond

--- a/src/sci/impl/interop.cljc
+++ b/src/sci/impl/interop.cljc
@@ -27,7 +27,15 @@
           (let [methods (Reflector/getMethods target-class (count args) method false)]
             (Reflector/invokeMatchingMethod method methods obj (object-array args)))))]))
 
-(declare get-static-field invoke-constructor)
+(defn get-static-field #?(:clj [[^Class class field-name-sym]]
+                          :cljs [[class field-name-sym]])
+  #?(:clj (Reflector/getStaticField class (str field-name-sym))
+     :cljs (gobj/get class field-name-sym)))
+
+(defn invoke-constructor #?(:clj [^Class class args]
+                            :cljs [constructor args])
+  #?(:clj (Reflector/invokeConstructor class (object-array args))
+     :cljs (apply constructor args)))
 
 (defn invoke-static-method #?(:clj [[^Class class method-name] args]
                               :cljs [[class method-name] args])
@@ -46,16 +54,6 @@
 
                  :else
                  (throw (js/Error. (str "Could not find static method " method-name))))))))
-
-(defn get-static-field #?(:clj [[^Class class field-name-sym]]
-                          :cljs [[class field-name-sym]])
-  #?(:clj (Reflector/getStaticField class (str field-name-sym))
-     :cljs (gobj/get class field-name-sym)))
-
-(defn invoke-constructor #?(:clj [^Class class args]
-                            :cljs [constructor args])
-  #?(:clj (Reflector/invokeConstructor class (object-array args))
-     :cljs (apply constructor args)))
 
 (defn fully-qualify-class [{:keys [:env :class->opts]} sym]
   (or #?(:clj (when (contains? class->opts sym) sym)

--- a/src/sci/impl/interop.cljc
+++ b/src/sci/impl/interop.cljc
@@ -3,8 +3,7 @@
   #?(:clj (:import [sci.impl Reflector]))
   (:require #?(:cljs [goog.object :as gobj])
             [sci.impl.vars :as vars]
-            #?(:cljs [clojure.string])
-            #?(:cljs [applied-science.js-interop :as js-interop])))
+            #?(:cljs [clojure.string])))
 
 ;; see https://github.com/clojure/clojure/blob/master/src/jvm/clojure/lang/Reflector.java
 ;; see invokeStaticMethod, getStaticField, etc.
@@ -37,7 +36,7 @@
      :cljs (if-let [method (gobj/get class method-name)]
              ;; (js/alert "hi") doesn't work with apply
              (if (= js/window class)
-               (js-interop/call class method-name args)
+               (.apply (gobj/get class method-name) class (to-array args))
                (apply method args))
              (let [method-name (str method-name)
                    [field sub-method-name] (clojure.string/split method-name #"\.")]

--- a/src/sci/impl/interop.cljc
+++ b/src/sci/impl/interop.cljc
@@ -32,7 +32,7 @@
      (Reflector/invokeStaticMethod class (str method-name) (object-array args))
      :cljs (if-let [method (gobj/get class method-name)]
              (apply method args)
-             (throw (js/Error. "Could not find method" method-name)))))
+             (throw (js/Error. (str "Could not find method " method-name))))))
 
 (defn get-static-field #?(:clj [[^Class class field-name-sym]]
                           :cljs [_])

--- a/src/sci/impl/interop.cljc
+++ b/src/sci/impl/interop.cljc
@@ -16,7 +16,7 @@
                (aget obj (subs method-name 1))
                (if-let [method (aget obj method-name)]
                  (apply method obj args)
-                 (throw (js/Error. (str "Could not find method: " method-name)))))]
+                 (throw (js/Error. (str "Could not find instance method: " method-name)))))]
       :clj
       [#_([obj method args]
         (invoke-instance-method obj nil method args))
@@ -32,7 +32,7 @@
      (Reflector/invokeStaticMethod class (str method-name) (object-array args))
      :cljs (if-let [method (gobj/get class method-name)]
              (apply method args)
-             (throw (js/Error. (str "Could not find method " method-name))))))
+             (throw (js/Error. (str "Could not find static method " method-name))))))
 
 (defn get-static-field #?(:clj [[^Class class field-name-sym]]
                           :cljs [[class field-name-sym]])

--- a/src/sci/impl/interop.cljc
+++ b/src/sci/impl/interop.cljc
@@ -3,7 +3,8 @@
   #?(:clj (:import [sci.impl Reflector]))
   (:require #?(:cljs [goog.object :as gobj])
             [sci.impl.vars :as vars]
-            #?(:cljs [clojure.string])))
+            #?(:cljs [clojure.string])
+            #?(:cljs [applied-science.js-interop :as js-interop])))
 
 ;; see https://github.com/clojure/clojure/blob/master/src/jvm/clojure/lang/Reflector.java
 ;; see invokeStaticMethod, getStaticField, etc.
@@ -34,7 +35,10 @@
   #?(:clj
      (Reflector/invokeStaticMethod class (str method-name) (object-array args))
      :cljs (if-let [method (gobj/get class method-name)]
-             (apply method args)
+             ;; (js/alert "hi") doesn't work with apply
+             (if (= js/window class)
+               (js-interop/call class method-name args)
+               (apply method args))
              (let [method-name (str method-name)
                    [field sub-method-name] (clojure.string/split method-name #"\.")]
                (cond

--- a/src/sci/impl/interop.cljc
+++ b/src/sci/impl/interop.cljc
@@ -35,9 +35,9 @@
              (throw (js/Error. (str "Could not find method " method-name))))))
 
 (defn get-static-field #?(:clj [[^Class class field-name-sym]]
-                          :cljs [_])
+                          :cljs [[class field-name-sym]])
   #?(:clj (Reflector/getStaticField class (str field-name-sym))
-     :cljs (throw (js/Error. "Not implemented yet."))))
+     :cljs (aget class (str field-name-sym))))
 
 (defn invoke-constructor #?(:clj [^Class class args]
                             :cljs [constructor args])

--- a/src/sci/impl/interop.cljc
+++ b/src/sci/impl/interop.cljc
@@ -50,7 +50,7 @@
 (defn get-static-field #?(:clj [[^Class class field-name-sym]]
                           :cljs [[class field-name-sym]])
   #?(:clj (Reflector/getStaticField class (str field-name-sym))
-     :cljs (aget class (str field-name-sym))))
+     :cljs (gobj/get class field-name-sym)))
 
 (defn invoke-constructor #?(:clj [^Class class args]
                             :cljs [constructor args])

--- a/test/sci/interop_test.cljc
+++ b/test/sci/interop_test.cljc
@@ -56,8 +56,10 @@
 
 #?(:cljs
    (deftest methods-on-static-fields
-     (is (= 42 (tu/eval* "(.log js/console \"42\")" {:classes {'js js/global}})))
-     (is (= 42 (tu/eval* "(js/console.log \"42\")"  {:classes {'js js/global}})))))
+     (is (= 42 (tu/eval* "(do (.log js/console \"42\") 42)" {:classes {:allow :all
+                                                                       'js js/global}})))
+     (is (= 42 (tu/eval* "(do (js/console.log \"42\") 42)" {:classes {:allow :all
+                                                                      'js js/global}})))))
 
 #?(:cljs
    (do (def fs (let [m (js->clj (js/require "fs"))]

--- a/test/sci/interop_test.cljc
+++ b/test/sci/interop_test.cljc
@@ -62,6 +62,11 @@
                                                                       'js js/global}})))))
 
 #?(:cljs
+   (deftest static-field-constructors
+     (is (= 42 (tu/eval* "(js/parseInt (.-message (js/Error. \"42\")))" {:classes {:allow :all
+                                                                                   'js js/global}})))))
+
+#?(:cljs
    (do (def fs (let [m (js->clj (js/require "fs"))]
                  (zipmap (map symbol (keys m)) (vals m))))
        (deftest add-object-as-namespace

--- a/test/sci/interop_test.cljc
+++ b/test/sci/interop_test.cljc
@@ -51,7 +51,8 @@
 
 #?(:cljs
    (deftest static-methods
-     (is (= \C (tu/eval* "(String/fromCharCode 67)" {:classes {'String js/String}})))))
+     (is (= \C (tu/eval* "(String/fromCharCode 67)" {:classes {'String js/String}})))
+     (is (= 42 (tu/eval* "(js/parseInt \"42\")"     {:classes {'js js/global}})))))
 
 #?(:cljs
    (do (def fs (let [m (js->clj (js/require "fs"))]

--- a/test/sci/interop_test.cljc
+++ b/test/sci/interop_test.cljc
@@ -55,6 +55,11 @@
      (is (= 42 (tu/eval* "(js/parseInt \"42\")"     {:classes {'js js/global}})))))
 
 #?(:cljs
+   (deftest methods-on-static-fields
+     (is (= 42 (tu/eval* "(.log js/console \"42\")" {:classes {'js js/global}})))
+     (is (= 42 (tu/eval* "(js/console.log \"42\")"  {:classes {'js js/global}})))))
+
+#?(:cljs
    (do (def fs (let [m (js->clj (js/require "fs"))]
                  (zipmap (map symbol (keys m)) (vals m))))
        (deftest add-object-as-namespace


### PR DESCRIPTION
Addition to #282 

`(js/alert "hi")` actually works now :)

I had to add the `js-interop` dependency. They do magic I don't understand, but apparently effective.

Examples cases:
```
sci.evalString("(do (js/console.log \"42\") 42)", {"classes": {"allow": "all", "js": window}, "bindings": {}})
sci.evalString("(do (String/fromCharCode 67))", {"classes": {"allow": "all", "js": window, "String": String}, "bindings": {}})
sci.evalString("(js/alert \"foo\")", {"classes": {"allow": "all", "js": window}, "bindings": {}})
```