### PR TITLE
Added :iterate-max to control number of function calls

### DIFF
--- a/src/sci/impl/opts.cljc
+++ b/src/sci/impl/opts.cljc
@@ -86,6 +86,7 @@
   [{:keys [:bindings :env
            :allow :deny
            :realize-max
+           :iterate-max
            :preset ;; used by malli
            :aliases
            :namespaces
@@ -100,14 +101,18 @@
         imports (merge default-imports imports)
         bindings bindings
         _ (init-env! env bindings aliases namespaces imports load-fn)
+        iterate-max (or iterate-max (:iterate-max preset))
         ctx (merge {:env env
                     :bindings {}
                     :allow (process-permissions (:allow preset) allow)
                     :deny (process-permissions (:deny preset) deny)
                     :realize-max (or realize-max (:realize-max preset))
+                    :iterate-max iterate-max
                     :features features
                     :dry-run dry-run
                     :readers readers
                     ::ctx true}
-                   (normalize-classes (merge default-classes classes)))]
+                   (normalize-classes (merge default-classes classes))
+                   (when iterate-max
+                     {:iterate-max-counter (atom iterate-max)}))]
     ctx))

--- a/src/sci/impl/utils.cljc
+++ b/src/sci/impl/utils.cljc
@@ -7,6 +7,7 @@
 #?(:clj (set! *warn-on-reflection* true))
 
 (derive :sci.error/realized-beyond-max :sci/error)
+(derive :sci.error/iterated-beyond-max :sci/error)
 
 (defn constant? [x]
   (or (number? x) (string? x) (keyword? x)))

--- a/test/sci/safety_test.cljc
+++ b/test/sci/safety_test.cljc
@@ -1,0 +1,27 @@
+(ns sci.safety-test
+  (:require
+   [clojure.test :as test :refer [deftest is]]
+   [sci.core :as sci :refer [eval-string]]
+   [sci.test-utils :as tu]))
+
+(deftest iterate-max-test
+  (when-not tu/native?
+    (let [d (try (tu/eval* "(loop [i 1000] (if (zero? i) :done (recur (dec i))))" {:iterate-max 100})
+                 (catch #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo) e
+                   (ex-data e)))]
+      (is (= :sci.error/iterated-beyond-max (:type d)))))
+  (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo)
+                        #"iteration"
+                        (tu/eval* "(reduce (fn [_ _]) (range 1000))" {:iterate-max 100})))
+  (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo)
+                        #"iteration"
+                        (tu/eval* "((fn pow [x n] (case n 1 x, (* x (pow x (dec n))))) 2 10)" {:iterate-max 10})))
+  (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo)
+                        #"iteration"
+                        (tu/eval*  "(loop [i 1000] (if (zero? i) :done (recur (dec i))))" {:iterate-max 100})))
+
+  (is (= :done (tu/eval*  "(loop [i 10] (if (zero? i) :done (recur (dec i))))" {:iterate-max 100})))
+  (is (= :done (tu/eval*  "(loop [i 1000] (if (zero? i) :done (recur (dec i))))" {})))
+
+  (is (= 1024 (tu/eval* "((fn pow [x n] (case n 1 x, (* x (pow x (dec n))))) 2 10)" {:iterate 100})))
+  (is (= 1024 (tu/eval* "((fn pow [x n] (case n 1 x, (* x (pow x (dec n))))) 2 10)" {}))))


### PR DESCRIPTION
This is an example implementation for issue #348 

It allows to control the number of functions call via the `iterate-max`.

In local `script/perf` checks this doesn't seem to affect performance ([before](https://github.com/borkdude/sci/commit/25ace7c8941fe10f1c158d567936c730e91ac289) and [after](https://github.com/borkdude/sci/commit/3c015315d8f940b6e011f25f5a070b0eef854f9b)). 

##  things to be discussed
- should this code be moved to analyzer.clj as suggested by @borkdude 
- naming of the option
- adding an elapsed time limit