### PR TITLE
[#375] allow re-binding of core vars with clojure.core/with-redefs

### DIFF
--- a/src/sci/core.cljc
+++ b/src/sci/core.cljc
@@ -18,14 +18,14 @@
   ([name] (doto (new-var name nil nil)
             (vars/unbind)))
   ([name init-val] (new-var name init-val (meta name)))
-  ([name init-val meta] (sci.impl.vars.SciVar. init-val name meta)))
+  ([name init-val meta] (sci.impl.vars.SciVar. init-val name meta false)))
 
 (defn new-dynamic-var
   "Same as new-var but adds :dynamic true to meta."
   ([name] (doto (new-dynamic-var name nil nil)
             (vars/unbind)))
   ([name init-val] (new-dynamic-var name init-val (meta name)))
-  ([name init-val meta] (sci.impl.vars.SciVar. init-val name (assoc meta :dynamic true))))
+  ([name init-val meta] (sci.impl.vars.SciVar. init-val name (assoc meta :dynamic true) false)))
 
 (defn new-macro-var
   "Same as new-var but adds :macro true to meta as well
@@ -34,7 +34,7 @@
   ([name init-val meta] (sci.impl.vars.SciVar.
                          (vary-meta init-val
                                     assoc :sci/macro true)
-                         name (assoc meta :macro true))))
+                         name (assoc meta :macro true) false)))
 
 (defmacro copy-var
   "Copies contents from var `sym` to a new sci var. The value `ns` is an

--- a/src/sci/impl/analyzer.cljc
+++ b/src/sci/impl/analyzer.cljc
@@ -477,7 +477,8 @@
                                                                   (assoc (meta name)
                                                                          :name name
                                                                          :ns @vars/current-ns
-                                                                         :file @vars/current-file))
+                                                                         :file @vars/current-file)
+                                                                  false)
                                                (vars/unbind)))))
                                   current-ns
                                   names))))))
@@ -644,12 +645,7 @@
             f (or special-sym
                   (resolve-symbol ctx f true))
             f (if (and (vars/var? f)
-                       (or
-                        (vars/isMacro f)
-                        (let [m (meta f)]
-                          (and
-                           (:sci.impl/built-in m)
-                           (not (:dynamic m))))))
+                       (vars/isMacro f))
                 @f f)
             f-meta (meta f)
             eval? (and f-meta (:sci.impl/op f-meta))]

--- a/src/sci/impl/analyzer.cljc
+++ b/src/sci/impl/analyzer.cljc
@@ -644,14 +644,7 @@
             _ (when special-sym (check-permission! ctx special-sym f))
             f (or special-sym
                   (resolve-symbol ctx f true))
-            f #_(if (and (vars/var? f)
-                       (or
-                        (vars/isMacro f)
-                        (let [m (meta f)]
-                          (and
-                           (:sci.impl/built-in m)
-                           (not (:dynamic m))))))
-                @f f) (if (and (vars/var? f)
+            f (if (and (vars/var? f)
                        (vars/isMacro f))
                 @f f)
             f-meta (meta f)

--- a/src/sci/impl/analyzer.cljc
+++ b/src/sci/impl/analyzer.cljc
@@ -644,7 +644,14 @@
             _ (when special-sym (check-permission! ctx special-sym f))
             f (or special-sym
                   (resolve-symbol ctx f true))
-            f (if (and (vars/var? f)
+            f #_(if (and (vars/var? f)
+                       (or
+                        (vars/isMacro f)
+                        (let [m (meta f)]
+                          (and
+                           (:sci.impl/built-in m)
+                           (not (:dynamic m))))))
+                @f f) (if (and (vars/var? f)
                        (vars/isMacro f))
                 @f f)
             f-meta (meta f)

--- a/src/sci/impl/interpreter.cljc
+++ b/src/sci/impl/interpreter.cljc
@@ -113,7 +113,8 @@
                 prev (get the-current-ns var-name)
                 prev (if-not (vars/var? prev)
                        (vars/->SciVar prev (symbol (str cnn) (str var-name))
-                                      (meta prev))
+                                      (meta prev)
+                                      false)
                        prev)
                 v (if (kw-identical? :sci.impl/var.unbound init)
                     (doto prev
@@ -559,7 +560,6 @@
   (try (let [f (first expr)
              m (meta f)
              op (when m (.get ^java.util.Map m :sci.impl/op))]
-         ;; (prn op expr)
          (cond
            (and (symbol? f) (not op))
            (eval-special-call ctx f expr)

--- a/src/sci/impl/namespaces.cljc
+++ b/src/sci/impl/namespaces.cljc
@@ -20,8 +20,7 @@
    [sci.impl.records :as records]
    [sci.impl.types :as types]
    [sci.impl.utils :as utils]
-   [sci.impl.vars :as vars]
-   [sci.impl.unrestrict :refer [*unrestricted*]])
+   [sci.impl.vars :as vars])
   #?(:cljs (:require-macros [sci.impl.namespaces :refer [copy-var copy-core-var]])))
 
 #?(:clj (set! *warn-on-reflection* true))

--- a/src/sci/impl/namespaces.cljc
+++ b/src/sci/impl/namespaces.cljc
@@ -20,7 +20,8 @@
    [sci.impl.records :as records]
    [sci.impl.types :as types]
    [sci.impl.utils :as utils]
-   [sci.impl.vars :as vars])
+   [sci.impl.vars :as vars]
+   [sci.impl.unrestrict :refer [*unrestricted*]])
   #?(:cljs (:require-macros [sci.impl.namespaces :refer [copy-var copy-core-var]])))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -40,7 +41,8 @@
                                        :name name#
                                        :arglists (:arglists m#)
                                        :ns ns#
-                                       :sci.impl/built-in true}))))
+                                       :sci.impl/built-in true}
+                       false))))
   (defmacro copy-core-var
     ([sym]
      `(copy-var ~sym clojure-core-ns)
@@ -417,7 +419,7 @@
          env (:env ctx)]
      (or (get-in @env [:namespaces ns-name var-sym])
          (let [var-name (symbol (str ns-name) (str var-sym))
-               new-var (vars/->SciVar nil var-name (meta var-sym))]
+               new-var (vars/->SciVar nil var-name (meta var-sym) false)]
            (vars/unbind new-var)
            (swap! env assoc-in [:namespaces ns-name var-sym] new-var)
            new-var))))
@@ -429,7 +431,7 @@
            (vars/bindRoot v val)
            v)
          (let [var-name (symbol (str ns-name) (str var-sym))
-               new-var (vars/->SciVar val var-name (meta var-sym))]
+               new-var (vars/->SciVar val var-name (meta var-sym) false)]
            (swap! env assoc-in [:namespaces ns-name var-sym] new-var)
            new-var)))))
 
@@ -978,7 +980,7 @@
    'unchecked-byte (copy-core-var unchecked-byte)
    'unchecked-short (copy-core-var unchecked-short)
    'underive (with-meta hierarchies/underive* {:sci.impl/op :needs-ctx})
-   'unquote (doto (vars/->SciVar nil 'clojure.core/unquote nil)
+   'unquote (doto (vars/->SciVar nil 'clojure.core/unquote nil false)
               (vars/unbind))
    'use (with-meta use {:sci.impl/op :needs-ctx})
    'val (copy-core-var val)

--- a/src/sci/impl/opts.cljc
+++ b/src/sci/impl/opts.cljc
@@ -19,7 +19,7 @@
                      namespaces (-> namespaces
                                     (update 'user assoc :aliases aliases)
                                     (update 'clojure.core assoc 'global-hierarchy
-                                            (vars/->SciVar (make-hierarchy) 'global-hierarchy nil)))]
+                                            (vars/->SciVar (make-hierarchy) 'global-hierarchy nil false)))]
                  (assoc env
                         :namespaces namespaces
                         :imports imports

--- a/src/sci/impl/vars.cljc
+++ b/src/sci/impl/vars.cljc
@@ -93,7 +93,6 @@
   (toSymbol [this])
   (isMacro [this])
   (hasRoot [this])
-  (isBound [this])
   (setThreadBound [this v])
   (unbind [this]))
 
@@ -136,12 +135,6 @@
                          :cljs @dvals)]
     (when-let [bindings (.-bindings f)]
       (get bindings sci-var))))
-
-#_(defn thread-bound? [sci-var]
-  (when-let [^Frame f #?(:clj (.get dvals)
-                         :cljs @dvals)]
-    (when-let [bindings (.-bindings f)]
-      (contains? bindings sci-var))))
 
 (defn binding-conveyor-fn
   [f]
@@ -259,9 +252,6 @@
     (:sci/macro (clojure.core/meta root)))
   (setThreadBound [this v]
     (set! (.-thread-bound this) v))
-  (isBound [this]
-    thread-bound #_(or (not (instance? SciUnbound root))
-        (thread-bound? this)))
   (unbind [this]
     (with-writeable-var this meta
       (set! (.-root this) (SciUnbound. this))))

--- a/src/sci/impl/vars.cljc
+++ b/src/sci/impl/vars.cljc
@@ -284,9 +284,11 @@
   #?(:clj clojure.lang.IDeref :cljs IDeref)
   (#?(:clj deref
       :cljs -deref) [this]
-    (or (when-let [tbox (get-thread-binding this)]
-          (t/getVal tbox))
-        root))
+    (if thread-bound
+      (or (when-let [tbox (get-thread-binding this)]
+            (t/getVal tbox))
+          root)
+      root))
   Object
   (toString [_]
     (str "#'" sym))

--- a/test/sci/vars_test.cljc
+++ b/test/sci/vars_test.cljc
@@ -3,6 +3,7 @@
    #?(:clj [sci.addons :as addons])
    [clojure.test :as test :refer [deftest is testing]]
    [sci.core :as sci]
+   [sci.impl.unrestrict :refer [*unrestricted*]]
    [sci.test-utils :as tu]))
 
 (defn eval*
@@ -180,4 +181,6 @@
          #?(:clj Exception :cljs js/Error)
          #"Built-in var"
          (sci/eval-string
-          "[(with-redefs [*x* (fn [] 11)] (*x*)) (*x*)]" {:bindings {'*x* x}})))))
+          "[(with-redefs [*x* (fn [] 11)] (*x*)) (*x*)]" {:bindings {'*x* x}}))))
+  (binding [*unrestricted* true]
+    (is (= {} (sci/eval-string "(with-redefs [assoc dissoc] (assoc {:a :b} :a :b))")))))


### PR DESCRIPTION
Instead of "directly linking" built-in vars we now let user re-bind core vars (in babashka) with `with-redefs`. With this we lost an optimization. But deref-ing a var is now optimized by bookkeeping if a var was ever thread-bound. If not, we get to the root value immediately instead of looking in thread-local bindings. 