### PR TITLE
Fix reflection warning on multimethods.cljc

### DIFF
--- a/src/sci/impl/multimethods.cljc
+++ b/src/sci/impl/multimethods.cljc
@@ -8,11 +8,12 @@
   as valid, else returns nil."
   [options & valid-keys]
   (when (seq (apply disj (apply hash-set (keys options)) valid-keys))
-    (throw
-     (new #?(:clj IllegalArgumentException :cljs js/Error)
-          (apply str "Only these options are valid: "
-                 (first valid-keys)
-                 (map #(str ", " %) (rest valid-keys)))))))
+    (let [message (apply str "Only these options are valid: "
+                         (first valid-keys)
+                         (map #(str ", " %) (rest valid-keys)))]
+      (throw     
+       #?(:clj (IllegalArgumentException. ^String message)
+          :cljs (js/Error. ^string message))))))
 
 (defn defmulti
   "Creates a new multimethod with the associated dispatch function.


### PR DESCRIPTION
I'm getting this warning when compiling sci with native image:

Reflection warning, sci/impl/multimethods.cljc:12:6 - call to java.lang.IllegalArgumentException ctor can't be resolved.