### PR TITLE
Inline fns

### DIFF
--- a/src/sci/impl/faster.cljc
+++ b/src/sci/impl/faster.cljc
@@ -1,0 +1,21 @@
+(ns sci.impl.faster
+  (:require [sci.impl.macros :refer [?]])
+  #?(:cljs (:require-macros [sci.impl.faster :refer [nth-2 assoc-2 get-2]])))
+
+(defmacro nth-2
+  [c i]
+  (?
+   :clj `(.nth ~(with-meta c {:tag 'clojure.lang.Indexed}) ~i)
+   :cljs `(~'-nth ~c ~i)))
+
+(defmacro assoc-2
+  [m k v]
+  (?
+   :clj `(.assoc ~(with-meta m {:tag 'clojure.lang.Associative}) ~k ~v)
+   :cljs `(~'-assoc ~m ~k ~v)))
+
+(defmacro get-2
+  [m k]
+  (?
+   :clj `(.get ~(with-meta m {:tag 'java.util.Map}) ~k)
+   :cljs `(.get ~m ~k)))

--- a/src/sci/impl/fns.cljc
+++ b/src/sci/impl/fns.cljc
@@ -1,7 +1,10 @@
 (ns sci.impl.fns
   {:no-doc true}
   (:require [sci.impl.types :as t]
-            [sci.impl.utils :as utils]))
+            [sci.impl.utils :as utils]
+            [sci.impl.macros :as macros :refer [?]])
+  #?(:cljs (:require-macros [sci.impl.fns :refer [gen-run-fn
+                                                  gen-run-fn*]])))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -18,50 +21,146 @@
   t/IBox
   (getVal [_] val))
 
+;; gen-run-fn expands into something like:
+
+#_(let [p1 (first params)
+        p2 (second params)]
+    (fn run-fn [x y]
+      (let [;; tried making bindings a transient, but saw no perf improvement (see #246)
+            bindings (.get ^java.util.Map ctx :bindings)
+            bindings (.assoc ^clojure.lang.Associative bindings p1 x)
+            bindings (.assoc ^clojure.lang.Associative bindings p2 y)
+            ctx #?(:clj (.assoc ctx :bindings bindings)
+                   :cljs (-assoc ctx :bindings bindings))
+            ret (return ctx)
+            ;; m (meta ret)
+            recur? (instance? Recur ret)]
+        (if recur?
+          (let [recur-val (t/getVal ret)]
+            (recur (first recur-val) (second recur-val)))
+          ret))))
+
+(defmacro gen-run-fn [n]
+  (let [locals (repeatedly n gensym)
+        fn-params (vec (repeatedly n gensym))
+        rnge (range n)
+        nths (map (fn [n]
+                    (? :clj `(.nth ~(with-meta 'params {:tag 'clojure.lang.Indexed}) ~n)
+                            :cljs (list '-nth 'params n)))
+                  rnge)
+        let-vec (vec (mapcat (fn [local ith]
+                               [local ith]) locals nths))
+        assocs (mapcat (fn [local fn-param]
+                         `[~'bindings ~(? :clj `(.assoc ~(with-meta 'bindings
+                                                           {:tag 'clojure.lang.Associative})
+                                                       ~local ~fn-param)
+                                               :cljs `(~'-assoc ~'bindings ~local ~fn-param))])
+                       locals fn-params)
+        recurs (map (fn [n]
+                      (? :clj `(.nth ~(with-meta 'recur-val {:tag 'clojure.lang.Indexed}) ~n)
+                              :cljs `(~'-nth ~'recur-val ~n)))
+                    rnge)]
+    `(let ~let-vec
+       (fn ~'run-fn ~fn-params
+         (? :cljs (when-not (:disable-arity-checks ~'ctx)
+                    (when-not (= ~n (.-length (~'js-arguments)))
+                      (throw-arity ~'ctx ~'fn-name ~'macro? (vals (~'js->clj (~'js-arguments)))))))
+         (let [;; tried making bindings a transient, but saw no perf improvement (see #246)
+               ~'bindings (.get ~(with-meta 'ctx {:tag 'java.util.Map}) :bindings)
+               ~@assocs
+               ctx# (? :clj (.assoc ~(with-meta 'ctx {:tag 'clojure.lang.Associative})
+                                    :bindings ~'bindings)
+                            :cljs (~'-assoc ~'ctx :bindings ~'bindings))
+               ret# (~'return ctx#)
+               ;; m (meta ret)
+               recur?# (instance? Recur ret#)]
+           (if recur?#
+             (let [~'recur-val (t/getVal ret#)]
+               (recur ~@recurs))
+             ret#))))))
+
+#_(require '[clojure.pprint :as pprint])
+#_(binding [*print-meta* true]
+    (pprint/pprint (macroexpand '(gen-run-fn 2))))
+
+(defmacro gen-run-fn* []
+  '(fn run-fn [& args]
+                (let [;; tried making bindings a transient, but saw no perf improvement (see #246)
+                      bindings (.get ^java.util.Map ctx :bindings)
+                      bindings
+                      (loop [args* (seq args)
+                             params (seq params)
+                             ret bindings]
+                        (if params
+                          (let [fp (first params)]
+                            (if (= '& fp)
+                              (assoc ret (second params) args*)
+                              (do
+                                (when-not args*
+                                  (throw-arity ctx fn-name macro? args))
+                                (recur (next args*) (next params)
+                                       (assoc ret fp (first args*))))))
+                          (do
+                            (when args*
+                              (throw-arity ctx fn-name macro? args))
+                            ret)))
+                      ctx (? :clj (.assoc ctx :bindings bindings)
+                                  :cljs (-assoc ctx :bindings bindings))
+                      ret (return ctx)
+                      ;; m (meta ret)
+                      recur? (instance? Recur ret)]
+                  (if recur?
+                    (let [recur-val (t/getVal ret)]
+                      (if min-var-args-arity
+                        (let [[fixed-args [rest-args]]
+                              [(subvec recur-val 0 min-var-args-arity)
+                               (subvec recur-val min-var-args-arity)]]
+                          (recur (into fixed-args rest-args)))
+                        (recur recur-val)))
+                    ret))))
+
 (defn parse-fn-args+body
   [^clojure.lang.Associative ctx interpret eval-do*
-   {:sci.impl/keys [fixed-arity var-arg-name params body] :as _m}
-   fn-name macro? with-meta?]
+   {:sci.impl/keys [fixed-arity var-arg-name
+                    #_:clj-kondo/ignore params body] :as _m}
+   #_:clj-kondo/ignore fn-name
+   #_:clj-kondo/ignore macro?
+   with-meta?]
   (let [min-var-args-arity (when var-arg-name fixed-arity)
         body-count (count body)
         return (if (= 1 body-count)
                  (let [fst (first body)]
                    #(interpret % fst))
                  #(eval-do* % body))
-        f (fn run-fn [& args]
-            (let [;; tried making bindings a transient, but saw no perf improvement (see #246)
-                  bindings (.get ^java.util.Map ctx :bindings)
-                  bindings
-                  (loop [args* (seq args)
-                         params (seq params)
-                         ret bindings]
-                    (if params
-                      (let [fp (first params)]
-                        (if (= '& fp)
-                          (assoc ret (second params) args*)
-                          (do
-                            (when-not args*
-                              (throw-arity ctx fn-name macro? args))
-                            (recur (next args*) (next params)
-                                   (assoc ret fp (first args*))))))
-                      (do
-                        (when args*
-                          (throw-arity ctx fn-name macro? args))
-                        ret)))
-                  ctx #?(:clj (.assoc ctx :bindings bindings)
-                         :cljs (-assoc ctx :bindings bindings))
-                  ret (return ctx)
-                  ;; m (meta ret)
-                  recur? (instance? Recur ret)]
-              (if recur?
-                (let [recur-val (t/getVal ret)]
-                  (if min-var-args-arity
-                    (let [[fixed-args [rest-args]]
-                          [(subvec recur-val 0 min-var-args-arity)
-                           (subvec recur-val min-var-args-arity)]]
-                      (recur (into fixed-args rest-args)))
-                    (recur recur-val)))
-                ret)))]
+        f (if-not (or var-arg-name
+                      #?(:clj (:disable-arity-checks ctx)))
+            (case (int fixed-arity)
+              0 (fn run-fn []
+                  (let [ret (return ctx)
+                        ;; m (meta ret)
+                        recur? (instance? Recur ret)]
+                    (if recur? (recur) ret)))
+              1 (gen-run-fn 1)
+              2 (gen-run-fn 2)
+              3 (gen-run-fn 3)
+              4 (gen-run-fn 4)
+              5 (gen-run-fn 5)
+              6 (gen-run-fn 6)
+              7 (gen-run-fn 7)
+              8 (gen-run-fn 8)
+              9 (gen-run-fn 9)
+              10 (gen-run-fn 10)
+              11 (gen-run-fn 11)
+              12 (gen-run-fn 11)
+              13 (gen-run-fn 11)
+              14 (gen-run-fn 11)
+              15 (gen-run-fn 11)
+              16 (gen-run-fn 11)
+              17 (gen-run-fn 17)
+              18 (gen-run-fn 18)
+              19 (gen-run-fn 19)
+              (gen-run-fn*))
+            (gen-run-fn*))]
     (if with-meta?
       (with-meta
         f
@@ -103,7 +202,7 @@
                                   (str "Cannot call " fn-name " with " actual-count " arguments")))))))))
         f (if macro?
             (vary-meta f
-             #(assoc % :sci/macro macro?))
+                       #(assoc % :sci/macro macro?))
             f)]
     (reset! self-ref f)
     f))

--- a/src/sci/impl/fns.cljc
+++ b/src/sci/impl/fns.cljc
@@ -68,9 +68,10 @@
          (let [;; tried making bindings a transient, but saw no perf improvement (see #246)
                ~'bindings (.get ~(with-meta 'ctx {:tag 'java.util.Map}) :bindings)
                ~@assocs
-               ctx# (? :clj (.assoc ~(with-meta 'ctx {:tag 'clojure.lang.Associative})
-                                    :bindings ~'bindings)
-                            :cljs (~'-assoc ~'ctx :bindings ~'bindings))
+               ctx# (?
+                     :clj (.assoc ~(with-meta 'ctx {:tag 'clojure.lang.Associative})
+                                  :bindings ~'bindings)
+                     :cljs (~'-assoc ~'ctx :bindings ~'bindings))
                ret# (~'return ctx#)
                ;; m (meta ret)
                recur?# (instance? Recur ret#)]

--- a/src/sci/impl/fns.cljc
+++ b/src/sci/impl/fns.cljc
@@ -14,7 +14,7 @@
                    :cljs js/Error)
                 (let [actual-count (if macro? (- (count args) 2)
                                        (count args))]
-                  (str "Cannot call " fn-name " with " actual-count " arguments"))))))
+                  (str "Wrong number of args (" actual-count ") passed to: " fn-name))))))
 
 (deftype Recur #?(:clj [val]
                   :cljs [val])
@@ -62,7 +62,7 @@
                     rnge)]
     `(let ~let-vec
        (fn ~'run-fn ~fn-params
-         (? :cljs (when-not (:disable-arity-checks ~'ctx)
+         (? :cljs (when-not (.get ~'ctx :disable-arity-checks)
                     (when-not (= ~n (.-length (~'js-arguments)))
                       (throw-arity ~'ctx ~'fn-name ~'macro? (vals (~'js->clj (~'js-arguments)))))))
          (let [;; tried making bindings a transient, but saw no perf improvement (see #246)

--- a/src/sci/impl/utils.cljc
+++ b/src/sci/impl/utils.cljc
@@ -1,7 +1,8 @@
 (ns sci.impl.utils
   {:no-doc true}
   (:require [sci.impl.types :as t]
-            [sci.impl.vars :as vars]))
+            [sci.impl.vars :as vars]
+            [clojure.string :as str]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -90,7 +91,11 @@
                           :cljs (.-message e))
                 {:keys [:line :column :file]
                  :or {line (:line ctx)
-                      column (:column ctx)}} (meta node)]
+                      column (:column ctx)}} (meta node)
+                ex-msg (if (and ex-msg (:name fm))
+                         (str/replace ex-msg #"(sci\.impl\.)?fns/parse-fn-args\+body/run-fn--\d+"
+                                      (str (:name fm)))
+                         ex-msg)]
             (if (and line column)
               (let [m ex-msg
                     new-exception

--- a/test/sci/core_test.cljc
+++ b/test/sci/core_test.cljc
@@ -363,26 +363,26 @@
          {:line 1 :column 19}
          (eval* "(+ 1 2 3 4 5) (do x)")))
     (tu/assert-submap {:type :sci/error, :line 1, :column 15,
-                       :message #"Cannot call foo with 1 arguments"}
+                       :message #"Wrong number of args \(1\) passed to: foo"}
                       (try (eval* "(defn foo []) (foo 1)")
                            (catch #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo) ex
                              (let [d (ex-data ex)]
                                d))))
     (tu/assert-submap {:type :sci/error, :line 1, :column 21,
-                       :message #"Cannot call foo with 0 arguments"}
+                       :message #"Wrong number of args \(0\) passed to: foo"}
                       (try (eval* "(defn foo [x & xs]) (foo)")
                            (catch #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo) ex
                              (let [d (ex-data ex)]
                                d))))
     (tu/assert-submap {:type :sci/error, :line 1, :column 93,
-                       :message #"Cannot call bindings"}
+                       :message #"Wrong number of args \(2\) passed to: bindings"}
                       (try (eval* (str "(defmacro bindings [a] (zipmap (mapv #(list 'quote %) (keys &env)) (keys &env))) "
                                        "(let [x 1] (bindings))"))
                            (catch #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo) ex
                              (let [d (ex-data ex)]
                                d))))
     (tu/assert-submap {:type :sci/error, :line 1, :column 25,
-                       :message #"Cannot call foo with 0 arguments"}
+                       :message #"Wrong number of args \(0\) passed to: foo"}
                       (try (eval* (str "(defmacro foo [x & xs]) "
                                        "(foo)"))
                            (catch #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo) ex


### PR DESCRIPTION
This yields about 8% performance improvement in this loop example:

```
$ time ./sci "(loop [val 0 cnt 1000000] (if (pos? cnt) (recur (inc val) (dec cnt)) val))"
1000000
./sci    0.92s  user 0.08s system 99% cpu 1.010 total
```
Used to be about 1s.