### PR TITLE
Preserve fully-qualified type for records

### DIFF
--- a/test/sci/records_test.cljc
+++ b/test/sci/records_test.cljc
@@ -118,3 +118,11 @@
             "(defprotocol IFoo (foo [this]))
              (defrecord Foo [x] IFoo (foo [this] (Foo. x)))
              (foo (Foo. 1))" {})))))
+
+
+(deftest type-name-test
+  (let [prog "
+(ns foo)
+(defrecord R [bar])
+(-> \"bar\" ->R meta :sci.impl/type str)"]
+    (is (= "foo.R" (tu/eval* prog {})))))


### PR DESCRIPTION
So far I only have a failing test. If I look at `*ns*` in the defrecord constructor, it's still `user`. Any pointers on how to get to `foo`?

Closes #492.