### PR TITLE
Add zprint to uses of sci.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Sci is used in:
 - [Prose](https://github.com/JeremS/prose). Alternate syntax for Clojure, similar to what Pollen brings to Racket.
 - [SICMUtils](https://github.com/littleredcomputer/sicmutils). Computer Algebra System in Clojure, tailored for math and physics investigations.
 - [Spire](https://github.com/epiccastle/spire). Pragmatic provisioning using Clojure.
+- [Zprint](https://github.com/kkinnear/zprint). Tool to beautifully format Clojure(script) code and data.
 
 Are you using sci in your company or projects? Let us know [here](https://github.com/babashka/babashka/issues/254).
 


### PR DESCRIPTION
As suggested, this will update the README.md to include `zprint`.  Thanks for creating `sci`, it made a significant difference in the capabilities of zprint, not least because I can now accept option maps in graalVM native images!