### PR TITLE
Avoid merging non-sci exception data into sci errors.

### DIFF
--- a/src/sci/impl/utils.cljc
+++ b/src/sci/impl/utils.cljc
@@ -128,10 +128,12 @@
                             :locals (or (:locals d)
                                         (:bindings ctx))}
                       phase (:phase ctx)
-                      base (if phase
-                             (assoc base :phase phase)
-                             base)]
-                  (ex-info ex-msg (merge base d) e))]
+                      wrapping-sci-error? (= :sci/error (:type d))
+                      ex-data (cond-> base
+                                      phase (assoc :phase phase)
+                                      wrapping-sci-error? (merge d)
+                                      (not wrapping-sci-error?) (assoc :ex-data d))]
+                  (ex-info ex-msg ex-data e))]
             (throw new-exception))
           (throw e))))))
 

--- a/test/sci/error_test.cljc
+++ b/test/sci/error_test.cljc
@@ -53,3 +53,20 @@
   (foo/echo-msg))  ;; called with the wrong arity
 
 (main)")))))
+
+(deftest inherited-ex-data-is-encapsulated
+  (testing "The original ex-data is encapsulated."
+    (is (= {:column 22
+            :ex-data {:ex :data}
+            :file nil
+            :line 2
+            :locals {}
+            :message "ex-message"
+            :type :sci/error}
+           (try
+             (eval-string "
+(defn throwing-fn [] (throw (ex-info \"ex-message\" {:ex :data})))
+
+(throwing-fn)")
+             (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
+               (dissoc (ex-data e) :sci.impl/callstack)))))))


### PR DESCRIPTION
Rather than always merging ex-data into the sci-error ex-data, only merge it when the underlying exception is itself a sci-error. 

Not certain on this line `wrapping-sci-error? (= :sci/error (:type d))` being sufficient, finding it a little hard to write a good test for the inverse case or to know all the possible types.

Part of a fix for https://github.com/babashka/babashka/issues/730