### PR TITLE
[#573] Pull apart bindings in eval

### DIFF
--- a/src/sci/impl/analyzer.cljc
+++ b/src/sci/impl/analyzer.cljc
@@ -646,7 +646,7 @@
                       (if (nil? args)
                         (if (str/starts-with? method-expr "-")
                           (ctx-fn
-                           (fn [_ctx]
+                           (fn [_ctx _bindings]
                              (interop/get-static-field [instance-expr (subs method-expr 1)]))
                            (with-meta [instance-expr (subs method-expr 1)]
                              {:sci.impl/op :static-access}))
@@ -662,7 +662,7 @@
                                    (try (Reflector/getStaticField ^Class instance-expr ^String method-expr)
                                         (catch IllegalArgumentException _ nil))]
                             (ctx-fn
-                             (fn [_ctx]
+                             (fn [_ctx _bindings]
                                (interop/get-static-field [instance-expr method-expr]))
                              (with-meta [instance-expr (subs method-expr 1)]
                                {:sci.impl/op :static-access})) #_(with-meta [instance-expr method-expr]
@@ -743,7 +743,7 @@
 ;;;; Namespaces
 
 (defn return-ns-op [_ctx f expr analyzed-args]
-  (ctx-fn (fn [ctx]
+  (ctx-fn (fn [ctx _bindings]
             (apply f ctx analyzed-args))
           expr))
 
@@ -789,7 +789,7 @@
          expr
          (conj ret
                (ctx-fn
-                (fn [ctx]
+                (fn [ctx _bindings]
                   (load/add-loaded-lib (:env ctx) ns-name)
                   nil)
                 nil)))))))

--- a/src/sci/impl/analyzer.cljc
+++ b/src/sci/impl/analyzer.cljc
@@ -166,16 +166,16 @@
             (mapcat (fn [[i binds]]
                       [i `(let ~binds
                             (ctx-fn
-                             (fn [~'ctx]
+                             (fn [~'ctx ~'bindings]
                                (and
                                 ~@(map (fn [j]
-                                         `(eval/eval ~'ctx ~(symbol (str "arg" j))))
+                                         `(eval/eval ~'ctx ~'bindings ~(symbol (str "arg" j))))
                                        (range i))))
                              ~'expr))])
                     let-bindings)
             `[(ctx-fn
-               (fn [~'ctx]
-                 (eval/eval-and ~'ctx ~'analyzed-children))
+               (fn [~'ctx ~'bindings]
+                 (eval/eval-and ~'ctx ~'bindings ~'analyzed-children))
                ~'expr)])))))
 
 (declare return-and) ;; for clj-kondo
@@ -335,7 +335,7 @@
                        (first fn-bodies))]
     (if fn-meta
       (fn [ctx bindings]
-        (let [fn-meta (eval/handle-meta ctx fn-meta)
+        (let [fn-meta (eval/handle-meta ctx bindings fn-meta)
               f (fns/eval-fn ctx bindings fn-name fn-bodies macro? single-arity self-ref?)]
           (vary-meta f merge fn-meta)))
       (fn [ctx bindings]
@@ -402,8 +402,8 @@
             m (assoc m :ns @vars/current-ns)
             m (if docstring (assoc m :doc docstring) m)]
         (ctx-fn
-         (fn [ctx]
-           (eval/eval-def ctx var-name init m))
+         (fn [ctx bindings]
+           (eval/eval-def ctx bindings var-name init m))
          expr)))))
 
 (defn expand-defn [ctx [op fn-name & body :as expr]]
@@ -446,8 +446,8 @@
         ctxfn (fn-ctx-fn ctx f fn-meta)
         f (ctx-fn ctxfn f f)]
     (ctx-fn
-     (fn [ctx]
-       (eval/eval-def ctx fn-name f meta-map))
+     (fn [ctx bindings]
+       (eval/eval-def ctx bindings fn-name f meta-map))
      expr)))
 
 (defn expand-loop
@@ -471,8 +471,8 @@
   [ctx expr]
   (let [body (rest expr)
         ana (analyze ctx (cons 'do body))]
-    (ctx-fn (fn [ctx]
-              (lazy-seq (eval/eval ctx ana)))
+    (ctx-fn (fn [ctx bindings]
+              (lazy-seq (eval/eval ctx bindings ana)))
             expr)))
 
 (defn return-if
@@ -535,10 +535,10 @@
                           (assoc-new ret-map k v))))
                      ret-map))
         f (if default?
-            (fn [ctx]
-              (eval/eval-case ctx case-map case-val case-default))
-            (fn [ctx]
-              (eval/eval-case ctx case-map case-val)))]
+            (fn [ctx bindings]
+              (eval/eval-case ctx bindings case-map case-val case-default))
+            (fn [ctx bindings]
+              (eval/eval-case ctx bindings case-map case-val)))]
     (ctx-fn
      f
      ;; legacy structure for error reporting
@@ -578,8 +578,8 @@
                       catches)
         finally (when finally
                   (analyze ctx (cons 'do (rest finally))))]
-    (ctx-fn (fn [ctx]
-              (eval/eval-try ctx body catches finally))
+    (ctx-fn (fn [ctx bindings]
+              (eval/eval-try ctx bindings body catches finally))
             expr)))
 
 (defn analyze-throw [ctx [_throw ex :as expr]]
@@ -589,8 +589,8 @@
         :cljs "Too many arguments to throw")
      expr))
   (let [ana (analyze ctx ex)]
-    (ctx-fn (fn [ctx]
-              (throw (eval/eval ctx ana)))
+    (ctx-fn (fn [ctx bindings]
+              (throw (eval/eval ctx bindings ana)))
             ;; legacy structure for error reporting
             (mark-eval-call (list 'throw)))))
 
@@ -679,16 +679,16 @@
                          (mark-eval-call (cons (with-meta [instance-expr method-expr]
                                                  {:sci.impl/op :static-access})
                                                args))))
-                      (ctx-fn (fn [ctx]
-                                (eval/eval-instance-method-invocation ctx instance-expr method-expr args))
+                      (ctx-fn (fn [ctx bindings]
+                                (eval/eval-instance-method-invocation ctx bindings instance-expr method-expr args))
                               ;; this info is used by set!
                               {::instance-expr instance-expr
                                ::method-expr method-expr}
                               ;; legacy error reporting for (.foo 1)
                               (mark-eval-call _expr)
                               ))
-               :cljs (ctx-fn (fn [ctx]
-                               (eval/eval-instance-method-invocation ctx instance-expr method-expr args))
+               :cljs (ctx-fn (fn [ctx bindings]
+                               (eval/eval-instance-method-invocation ctx bindings instance-expr method-expr args))
                              ;; this info is used by set!
                              {::instance-expr instance-expr
                               ::method-expr method-expr}
@@ -717,9 +717,9 @@
               :cljs {:keys [:constructor] :as _opts}) (interop/resolve-class-opts ctx class-sym)]
     (let [args (analyze-children ctx args)] ;; analyze args!
       (ctx-fn
-       (fn [ctx]
+       (fn [ctx bindings]
          (interop/invoke-constructor #?(:clj class :cljs constructor)
-                                     (mapv #(eval/eval ctx %) args)))
+                                     (mapv #(eval/eval ctx bindings %) args)))
        expr))
     (if-let [record (records/resolve-record-class ctx class-sym)]
       (let [args (analyze-children ctx args)]
@@ -808,8 +808,8 @@
               _ (when-not (vars/var? obj)
                   (throw-error-with-location "Invalid assignment target" expr))
               v (analyze ctx v)]
-          (ctx-fn (fn [ctx]
-                    (let [v (eval/eval ctx v)]
+          (ctx-fn (fn [ctx bindings]
+                    (let [v (eval/eval ctx bindings v)]
                       (types/setVal obj v)))
                   expr))
         #?@(:cljs [(seq? obj)
@@ -818,9 +818,9 @@
                          obj (types/info obj)
                          k (subs (::method-expr obj) 1)
                          obj (::instance-expr obj)]
-                     (ctx-fn (fn [ctx]
-                               (let [obj (eval/eval ctx obj)
-                                     v (eval/eval ctx v)]
+                     (ctx-fn (fn [ctx bindings]
+                               (let [obj (eval/eval ctx bindings obj)
+                                     v (eval/eval ctx bindings v)]
                                  (gobject/set obj k v)))
                              expr))])
         :else (throw-error-with-location "Invalid assignment target" expr)))
@@ -839,19 +839,19 @@
                           (range 20))]
     `(defn ~'return-binding-call
        ~'[_ctx expr f analyzed-children]
-       #_(ctx-fn
+       (ctx-fn
         (case (count ~'analyzed-children)
           ~@(concat
              (mapcat (fn [[i binds]]
                        [i `(let ~binds
-                             (fn [~'ctx]
-                               ((eval/resolve-symbol ~'ctx ~'f)
+                             (fn [~'ctx ~'bindings]
+                               ((eval/resolve-symbol ~'bindings ~'f)
                                 ~@(map (fn [j]
-                                         `(eval/eval ~'ctx ~(symbol (str "arg" j))))
+                                         `(eval/eval ~'ctx ~'bindings ~(symbol (str "arg" j))))
                                        (range i)))))])
                      let-bindings)
-             `[(fn [~'ctx]
-                 (eval/fn-call ~'ctx (eval/resolve-symbol ~'ctx ~'f) ~'analyzed-children))]))
+             `[(fn [~'ctx ~'bindings]
+                 (eval/fn-call ~'ctx ~'bindings (eval/resolve-symbol ~'bindings ~'f) ~'analyzed-children))]))
         ~'expr))))
 
 (declare return-binding-call) ;; for clj-kondo
@@ -872,14 +872,14 @@
           ~@(concat
              (mapcat (fn [[i binds]]
                        [i `(let ~binds
-                             (fn [~'ctx]
+                             (fn [~'ctx ~'bindings]
                                (~'f ~'ctx
                                 ~@(map (fn [j]
-                                         `(eval/eval ~'ctx ~(symbol (str "arg" j))))
+                                         `(eval/eval ~'ctx ~'bindings ~(symbol (str "arg" j))))
                                        (range i)))))])
                      let-bindings)
-             `[(fn [~'ctx]
-                 (eval/fn-call ~'ctx ~'f (cons ~'ctx ~'analyzed-children)))]))
+             `[(fn [~'ctx ~'bindings]
+                 (eval/fn-call ~'ctx ~'bindings ~'f (cons ~'ctx ~'analyzed-children)))]))
         ~'expr))))
 
 (declare return-needs-ctx-call) ;; for clj-kondo
@@ -921,19 +921,19 @@
   (when-not (= 2 (count expr))
     (throw-error-with-location "Wrong number of args (0) passed to quote" expr))
   (let [snd (second expr)]
-    (ctx-fn (fn [_ctx] snd) expr)))
+    (ctx-fn (fn [_ctx _bindings] snd) expr)))
 
 (defn analyze-in-ns [ctx expr]
   (let [ns-expr (analyze ctx (second expr))]
-    (ctx-fn (fn [ctx]
-              (let [ns-sym (eval/eval ctx ns-expr)]
+    (ctx-fn (fn [ctx bindings]
+              (let [ns-sym (eval/eval ctx bindings ns-expr)]
                 (set-namespace! ctx ns-sym nil)
                 nil))
             expr)))
 
 (defn analyze-import [_ctx expr]
   (let [args (rest expr)]
-    (ctx-fn (fn [ctx]
+    (ctx-fn (fn [ctx _bindings]
               (apply eval/eval-import ctx args))
             (mark-eval-call expr))))
 
@@ -954,8 +954,8 @@
                   #?(:clj (expand-dot** ctx (list* '. (first f) (second f) (rest expr)))
                      :cljs
                      (let [children (analyze-children ctx (rest expr))]
-                       (ctx-fn (fn [ctx]
-                                 (eval/eval-static-method-invocation ctx (cons f children)))
+                       (ctx-fn (fn [ctx bindings]
+                                 (eval/eval-static-method-invocation ctx bindings (cons f children)))
                                expr)))
                   (and (not eval?) ;; the symbol is not a binding
                        (or
@@ -1073,14 +1073,14 @@
             (case ccount
               1 (let [arg (nth children 0)]
                   (ctx-fn
-                   (fn [ctx]
-                     (f (eval/eval ctx arg)))
+                   (fn [ctx bindings]
+                     (f (eval/eval ctx bindings arg)))
                    expr))
               2 (let [arg0 (nth children 0)
                       arg1 (nth children 1)]
-                  (ctx-fn (fn [ctx]
-                            (f (eval/eval ctx arg0)
-                               (eval/eval ctx arg1)))
+                  (ctx-fn (fn [ctx bindings]
+                            (f (eval/eval ctx bindings arg0)
+                               (eval/eval ctx bindings arg1)))
                           expr))
               (throw-error-with-location (str "Wrong number of args (" ccount ") passed to: " f) expr)))
           :else
@@ -1129,9 +1129,9 @@
                                 :cljs sci.impl.types/EvalFn)
                              analyzed-map)
                 (ctx-fn
-                 (fn [ctx]
-                   (let [md (eval/handle-meta ctx analyzed-meta)
-                         coll (eval/eval ctx analyzed-map)]
+                 (fn [ctx bindings]
+                   (let [md (eval/handle-meta ctx bindings analyzed-meta)
+                         coll (eval/eval ctx bindings analyzed-map)]
                      (with-meta coll md)))
                  expr)
                 (with-meta analyzed-map analyzed-meta))
@@ -1153,9 +1153,9 @@
                           ;; can we transform this into return-call?
                           (let [ef (return-call ctx expr f2 (analyze-children ctx expr))]
                             (ctx-fn
-                             (fn [ctx]
-                               (let [md (eval/eval ctx analyzed-meta)
-                                     coll (eval/eval ctx ef)]
+                             (fn [ctx bindings]
+                               (let [md (eval/eval ctx bindings analyzed-meta)
+                                     coll (eval/eval ctx bindings ef)]
                                  (with-meta coll md)))
                              expr))
                           (return-call ctx expr f2 (analyze-children ctx expr))))]

--- a/src/sci/impl/evaluator.cljc
+++ b/src/sci/impl/evaluator.cljc
@@ -26,12 +26,12 @@
 
 (defn eval-and
   "The and macro from clojure.core. Note: and is unrolled in the analyzer, this is a fallback."
-  [ctx args]
+  [ctx bindings args]
   (let [args (seq args)]
     (loop [args args]
       (if args
         (let [x (first args)
-              v (eval ctx x)]
+              v (eval ctx bindings x)]
           (if v
             (let [xs (next args)]
               (if xs
@@ -40,12 +40,12 @@
 
 (defn eval-or
   "The or macro from clojure.core. Note: or is unrolled in the analyzer, this is a fallback."
-  [ctx args]
+  [ctx bindings args]
   (let [args (seq args)]
     (loop [args args]
       (when args
         (let [x (first args)
-              v (eval ctx x)]
+              v (eval ctx bindings x)]
           (if v v
               (let [xs (next args)]
                 (if xs (recur xs)
@@ -53,53 +53,55 @@
 
 (defn eval-let
   "The let macro from clojure.core"
-  [ctx let-bindings exprs]
-  (let [ctx (loop [ctx ctx
-                   let-bindings let-bindings]
-              (let [let-name (first let-bindings)
-                    let-bindings (rest let-bindings)
-                    let-val (first let-bindings)
-                    rest-let-bindings (next let-bindings)
-                    v (eval ctx let-val)
-                    bindings (faster/get-2 ctx :bindings)
-                    bindings (faster/assoc-3 bindings let-name v)
-                    ctx (faster/assoc-3 ctx :bindings bindings)]
-                (if-not rest-let-bindings
-                  ctx
-                  (recur ctx
-                         rest-let-bindings))))]
+  [ctx bindings let-bindings exprs]
+  (let [[ctx bindings] (loop [ctx ctx
+                              bindings bindings
+                              let-bindings let-bindings]
+                         (let [let-name (first let-bindings)
+                               let-bindings (rest let-bindings)
+                               let-val (first let-bindings)
+                               rest-let-bindings (next let-bindings)
+                               v (eval ctx bindings let-val)
+                               ;; bindings (faster/get-2 ctx :bindings)
+                               bindings (faster/assoc-3 bindings let-name v)
+                               ;; ctx (faster/assoc-3 ctx :bindings bindings)
+                               ]
+                           (if-not rest-let-bindings
+                             [ctx bindings]
+                             (recur ctx bindings
+                                    rest-let-bindings))))]
     (when exprs
       (loop [exprs exprs]
         (let [e (first exprs)
-              ret (eval ctx e)
+              ret (eval ctx bindings e)
               nexprs (next exprs)]
           (if nexprs (recur nexprs)
               ret))))))
 
-(defn handle-meta [ctx m]
+(defn handle-meta [ctx bindings m]
   ;; Sometimes metadata needs eval. In this case the metadata has metadata.
   (-> (if-let [mm (meta m)]
         (if (when mm (get-2 mm :sci.impl/op))
-          (eval ctx m)
+          (eval ctx bindings m)
           m)
         m)
       (dissoc :sci.impl/op)))
 
 (defn eval-map
-  [ctx expr]
+  [ctx bindings expr]
   (if-let [m (meta expr)]
     (if (kw-identical? :eval (:sci.impl/op m))
-      (with-meta (zipmap (map #(eval ctx %) (keys expr))
-                         (map #(eval ctx %) (vals expr)))
-        (handle-meta ctx m))
+      (with-meta (zipmap (map #(eval ctx bindings %) (keys expr))
+                         (map #(eval ctx bindings %) (vals expr)))
+        (handle-meta ctx bindings m))
       expr)
     expr))
 
 (defn eval-def
-  [ctx var-name init m]
-  (let [init (eval ctx init)
+  [ctx bindings var-name init m]
+  (let [init (eval ctx bindings init)
         m (or m (meta var-name))
-        m (eval-map ctx m) ;; m is marked with eval op in analyzer only when necessary
+        m (eval-map ctx bindings m) ;; m is marked with eval op in analyzer only when necessary
         cnn (vars/getName (:ns m))
         assoc-in-env
         (fn [env]
@@ -122,31 +124,30 @@
     ;; return var
     (get (get (get env :namespaces) cnn) var-name)))
 
-(defmacro resolve-symbol [ctx sym]
-  `(.get ^java.util.Map
-         (.get ~(with-meta ctx
-                  {:tag 'java.util.Map}) :bindings) ~sym))
+(defmacro resolve-symbol [bindings sym]
+  `(.get ~(with-meta bindings
+            {:tag 'java.util.Map}) ~sym))
 
 (declare eval-string*)
 
 (defn eval-case
-  ([ctx case-map case-val]
-   (let [v (eval ctx case-val)]
+  ([ctx bindings case-map case-val]
+   (let [v (eval ctx bindings case-val)]
      (if-let [[_ found] (find case-map v)]
-       (eval ctx found)
+       (eval ctx bindings found)
        (throw (new #?(:clj IllegalArgumentException :cljs js/Error)
                    (str "No matching clause: " v))))))
-  ([ctx case-map case-val case-default]
-   (let [v (eval ctx case-val)]
+  ([ctx bindings case-map case-val case-default]
+   (let [v (eval ctx bindings case-val)]
      (if-let [[_ found] (find case-map v)]
-       (eval ctx found)
-       (eval ctx case-default)))))
+       (eval ctx bindings found)
+       (eval ctx bindings case-default)))))
 
 (defn eval-try
-  [ctx body catches finally]
+  [ctx bindings body catches finally]
   (try
     (binding [utils/*in-try* true]
-      (eval ctx body))
+      (eval ctx bindings body))
     (catch #?(:clj Throwable :cljs js/Error) e
       (if-let
           [[_ r]
@@ -155,22 +156,22 @@
                        (when (instance? clazz e)
                          (reduced
                           [::try-result
-                           (eval (assoc-in ctx [:bindings (:binding c)]
-                                           e)
+                           (eval ctx
+                                 (assoc bindings c e )
                                  (:body c))]))))
                    nil
                    catches)]
         r
         (rethrow-with-location-of-node ctx e body)))
     (finally
-      (eval ctx finally))))
+      (eval ctx bindings finally))))
 
 ;;;; Interop
 
-(defn eval-static-method-invocation [ctx expr]
+(defn eval-static-method-invocation [ctx bindings expr]
   (interop/invoke-static-method (first expr)
                                 ;; eval args!
-                                (map #(eval ctx %) (rest expr))))
+                                (map #(eval ctx bindings %) (rest expr))))
 
 #?(:clj
    (defn super-symbols [clazz]
@@ -178,10 +179,10 @@
      (map #(symbol (.getName ^Class %)) (supers clazz))))
 
 (defn eval-instance-method-invocation
-  [ctx instance-expr method-str args]
+  [ctx bindings instance-expr method-str args]
   (let [instance-meta (meta instance-expr)
         tag-class (:tag-class instance-meta)
-        instance-expr* (eval ctx instance-expr)]
+        instance-expr* (eval ctx bindings instance-expr)]
     (if (and (map? instance-expr*)
              (:sci.impl/record (meta instance-expr*))) ;; a sci record
       (get instance-expr* (keyword (subs method-str 1)))
@@ -200,7 +201,7 @@
         ;; of instance-expr is at analysis time
         (when-not target-class
           (throw-error-with-location (str "Method " method-str " on " instance-class " not allowed!") instance-expr))
-        (let [args (map #(eval ctx %) args)] ;; eval args!
+        (let [args (map #(eval ctx bindings %) args)] ;; eval args!
           (interop/invoke-instance-method instance-expr* target-class method-str args))))))
 
 ;;;; End interop
@@ -210,12 +211,12 @@
 (declare eval-form)
 
 (defn eval-resolve
-  ([ctx sym]
-   (let [sym (eval ctx sym)]
+  ([ctx bindings sym]
+   (let [sym (eval ctx bindings sym)]
      (second (@utils/lookup ctx sym false))))
-  ([ctx env sym]
+  ([ctx bindings env sym]
    (when-not (contains? env sym)
-     (let [sym (eval ctx sym)]
+     (let [sym (eval ctx bindings sym)]
        (second (@utils/lookup ctx sym false))))))
 
 (vreset! utils/eval-resolve-state eval-resolve)
@@ -267,11 +268,11 @@
 
 (defn eval-do
   "Note: various arities of do have already been unrolled in the analyzer."
-  [ctx exprs]
+  [ctx bindings exprs]
   (let [exprs (seq exprs)]
     (loop [exprs exprs]
       (when exprs
-        (let [ret (eval ctx (first exprs))]
+        (let [ret (eval ctx bindings (first exprs))]
           (if-let [exprs (next exprs)]
             (recur exprs)
             ret))))))
@@ -280,17 +281,17 @@
 
 (macros/deftime
   ;; This macro generates a function of the following form for 20 arities:
-  #_(defn fn-call [ctx f args]
+  #_(defn fn-call [ctx bindings f args]
       (case (count args)
         0 (f)
-        1 (let [arg (eval ctx (first args))]
+        1 (let [arg (eval ctx bindings (first args))]
             (f arg))
-        2 (let [arg1 (eval ctx (first args))
+        2 (let [arg1 (eval ctx bindings (first args))
                 args (rest args)
-                arg2 (eval ctx (first args))]
+                arg2 (eval ctx bindings (first args))]
             (f arg1 arg2))
         ,,,
-        (let [args (mapv #(eval ctx %) args)]
+        (let [args (mapv #(eval ctx bindings %) args)]
           (apply f args))))
   (defmacro def-fn-call []
     (let [cases
@@ -298,17 +299,17 @@
                     [i (let [arg-syms (map (fn [_] (gensym "arg")) (range i))
                              args-sym 'args ;; (gensym "args")
                              let-syms (interleave arg-syms (repeat args-sym))
-                             let-vals (interleave (repeat `(eval ~'ctx (first ~args-sym)))
+                             let-vals (interleave (repeat `(eval ~'ctx ~'bindings (first ~args-sym)))
                                                   (repeat `(rest ~args-sym)))
                              let-bindings (vec (interleave let-syms let-vals))]
                          `(let ~let-bindings
                             (~'f ~@arg-syms)))]) (range 20))
-          cases (concat cases ['(let [args (mapv #(eval ctx %) args)]
+          cases (concat cases ['(let [args (mapv #(eval ctx bindings %) args)]
                                   (apply f args))])]
       ;; Normal apply:
       #_`(defn ~'fn-call ~'[ctx f args]
            (apply ~'f (map #(eval ~'ctx %) ~'args)))
-      `(defn ~'fn-call ~'[ctx f args]
+      `(defn ~'fn-call ~'[ctx bindings f args]
          ;; TODO: can we prevent hitting this at all, by analyzing more efficiently?
          ;; (prn :count ~'f ~'(count args) ~'args)
          (case ~'(count args)
@@ -317,12 +318,12 @@
 (def-fn-call)
 
 (defn eval
-  [ctx expr]
+  [ctx bindings expr]
   (try
     (cond (instance? #?(:clj sci.impl.types.EvalFn
                         :cljs sci.impl.types/EvalFn) expr)
           (let [f (.-f ^sci.impl.types.EvalFn expr)]
-            (f ctx))
+            (f ctx bindings))
           (instance? #?(:clj sci.impl.types.EvalVar
                         :cljs sci.impl.types/EvalVar) expr)
           (let [v (.-v ^sci.impl.types.EvalVar expr)]
@@ -330,7 +331,7 @@
           #?(:clj (instance? clojure.lang.IPersistentMap expr)
              :cljs (if (nil? expr) false
                        (satisfies? IMap expr)))
-          (eval-map ctx expr)
+          (eval-map ctx bindings expr)
           :else expr)
     (catch #?(:clj Throwable :cljs js/Error) e
       (rethrow-with-location-of-node ctx e expr))))

--- a/src/sci/impl/evaluator.cljc
+++ b/src/sci/impl/evaluator.cljc
@@ -157,7 +157,7 @@
                          (reduced
                           [::try-result
                            (eval ctx
-                                 (assoc bindings c e )
+                                 (assoc bindings (:binding c) e)
                                  (:body c))]))))
                    nil
                    catches)]

--- a/src/sci/impl/evaluator.cljc
+++ b/src/sci/impl/evaluator.cljc
@@ -162,7 +162,7 @@
                    nil
                    catches)]
         r
-        (rethrow-with-location-of-node ctx e body)))
+        (rethrow-with-location-of-node ctx bindings e body)))
     (finally
       (eval ctx bindings finally))))
 
@@ -334,6 +334,6 @@
           (eval-map ctx bindings expr)
           :else expr)
     (catch #?(:clj Throwable :cljs js/Error) e
-      (rethrow-with-location-of-node ctx e expr))))
+      (rethrow-with-location-of-node ctx bindings e expr))))
 
 (vreset! utils/eval* eval)

--- a/src/sci/impl/fns.cljc
+++ b/src/sci/impl/fns.cljc
@@ -228,10 +228,10 @@
   (or (get arities arity)
       (:variadic arities)))
 
-(defn fn-arity-map [ctx fn-name macro? fn-bodies]
+(defn fn-arity-map [ctx bindings fn-name macro? fn-bodies]
   (reduce
    (fn [arity-map fn-body]
-     (let [f (fun ctx fn-body fn-name macro?)
+     (let [f (fun ctx bindings fn-body fn-name macro?)
            var-arg? (:var-arg-name fn-body)
            fixed-arity (:fixed-arity fn-body)]
        (if var-arg?
@@ -249,7 +249,7 @@
                    bindings)
         f (if single-arity
             (fun ctx bindings single-arity fn-name macro?)
-            (let [arities (fn-arity-map ctx fn-name macro? fn-bodies)]
+            (let [arities (fn-arity-map ctx bindings fn-name macro? fn-bodies)]
               (fn [& args]
                 (let [arg-count (count args)]
                   (if-let [f (lookup-by-arity arities arg-count)]

--- a/src/sci/impl/fns.cljc
+++ b/src/sci/impl/fns.cljc
@@ -86,7 +86,6 @@
      (let [;; tried making bindings a transient, but saw no perf improvement
            ;; it's even slower with less than ~10 bindings which is pretty uncommon
            ;; see https://github.com/borkdude/sci/issues/559
-           bindings (.get ^java.util.Map ctx :bindings)
            bindings
            (loop [args* (seq args)
                   params (seq params)
@@ -104,8 +103,7 @@
                  (when args*
                    (throw-arity ctx nsm fn-name macro? args))
                  ret)))
-           ctx (assoc-3 ctx :bindings bindings)
-           ret (eval/eval ctx body)
+           ret (eval/eval ctx bindings body)
            ;; m (meta ret)
            recur? (instance? Recur ret)]
        (if recur?

--- a/src/sci/impl/interpreter.cljc
+++ b/src/sci/impl/interpreter.cljc
@@ -24,7 +24,7 @@
   (prn (zipmap (keys @stats)
                (map #(/ (double %) 1000000.0) (vals @stats)))))
 
-(defn eval-form-stats [ctx form]
+#_(defn eval-form-stats [ctx form]
   (if (seq? form)
     (if (= 'do (first form))
       (loop [exprs (rest form)
@@ -73,17 +73,19 @@
                 (= 'ns (first form))
                 (= 'require (first form)))
         (let [analyzed (ana/analyze ctx form true)
+              bindings (:bindings ctx)
               ret (if (instance? sci.impl.types.EvalForm analyzed)
                     (eval-form ctx (t/getVal analyzed))
-                    (eval/eval ctx analyzed))]
+                    (eval/eval ctx bindings analyzed))]
           ret)))
     (let [analyzed (ana/analyze ctx form)
-          ret (eval/eval ctx analyzed)]
+          bindings (:bindings ctx)
+          ret (eval/eval ctx bindings analyzed)]
       ret)))
 
-#?(:clj
-   (when (System/getenv "SCI_STATS")
-     (alter-var-root #'eval-form (constantly eval-form-stats))))
+;; #?(:clj
+;;    (when (System/getenv "SCI_STATS")
+;;      (alter-var-root #'eval-form (constantly eval-form-stats))))
 
 (vreset! utils/eval-form-state eval-form)
 

--- a/src/sci/impl/namespaces.cljc
+++ b/src/sci/impl/namespaces.cljc
@@ -525,9 +525,9 @@
 
 (defn sci-resolve
   ([sci-ctx sym]
-   (@utils/eval-resolve-state sci-ctx sym))
+   (@utils/eval-resolve-state sci-ctx (:bindings sci-ctx) sym))
   ([sci-ctx env sym]
-   (@utils/eval-resolve-state sci-ctx env sym)))
+   (@utils/eval-resolve-state sci-ctx (:bindings sci-ctx) env sym)))
 
 (defn sci-refer [sci-ctx & args]
   (apply @utils/eval-refer-state sci-ctx args))

--- a/src/sci/impl/protocols.cljc
+++ b/src/sci/impl/protocols.cljc
@@ -56,7 +56,7 @@
 
 (defn extend-protocol [_ _ ctx protocol-name & impls]
   (let [impls (utils/split-when #(not (seq? %)) impls)
-        protocol-var (@utils/eval-resolve-state ctx protocol-name)
+        protocol-var (@utils/eval-resolve-state ctx (:bindingx ctx) protocol-name)
         protocol-ns (-> protocol-var deref :ns)
         pns (str (vars/getName protocol-ns))
         fq-meth-name #(symbol pns %)
@@ -97,7 +97,7 @@
 (defn extend-type [_ _ ctx atype & proto+meths]
   (let [proto+meths (utils/split-when #(not (seq? %)) proto+meths)]
     `(do ~@(map (fn [[proto & meths]]
-                  (let [protocol-var (@utils/eval-resolve-state ctx proto)
+                  (let [protocol-var (@utils/eval-resolve-state ctx (:bindings ctx) proto)
                         protocol-ns (-> protocol-var deref :ns)
                         pns (str (vars/getName protocol-ns))
                         fq-meth-name #(symbol pns %)]

--- a/src/sci/impl/records.cljc
+++ b/src/sci/impl/records.cljc
@@ -24,7 +24,7 @@
         (mapcat
          (fn [[protocol-name & impls] #?(:clj expr :cljs expr)]
            (let [impls (group-by first impls)
-                 protocol (@utils/eval-resolve-state ctx protocol-name)
+                 protocol (@utils/eval-resolve-state ctx (:bindings ctx) protocol-name)
                  _ (when-not protocol
                      (utils/throw-error-with-location
                       (str "Protocol not found: " protocol-name)

--- a/src/sci/impl/resolve.cljc
+++ b/src/sci/impl/resolve.cljc
@@ -57,7 +57,7 @@
                       [clazz sym-name]
                       {:sci.impl.analyzer/static-access true})
                     (ctx-fn
-                     (fn [_ctx]
+                     (fn [_ctx _bindings]
                        (interop/get-static-field [clazz sym-name]))
                      (with-meta [clazz sym-name]
                        {:sci.impl/op :static-access

--- a/src/sci/impl/resolve.cljc
+++ b/src/sci/impl/resolve.cljc
@@ -97,8 +97,8 @@
              v (if call? ;; resolve-symbol is already handled in the call case
                  (mark-resolve-sym k)
                  (ctx-fn
-                  (fn [ctx]
-                    (eval/resolve-symbol ctx k))
+                  (fn [_ctx bindings]
+                    (eval/resolve-symbol bindings k))
                   k))]
          [k v]))
      (when-let [kv (lookup* ctx sym call?)]

--- a/src/sci/impl/utils.cljc
+++ b/src/sci/impl/utils.cljc
@@ -62,60 +62,62 @@
 
 (def needs-ctx (symbol "needs-ctx"))
 
-(defn rethrow-with-location-of-node [ctx ^Throwable e raw-node]
-  (if *in-try* (throw e)
-      (let [node (t/sexpr raw-node)
-            m (meta node)
-            f (when (seqable? node) (first node))
-            fm (some-> f meta)
-            op (when (and fm m)
-                 (.get ^java.util.Map m :sci.impl/op))
-            special? (or
-                      ;; special call like def
-                      (and (symbol? f) (not op))
-                      ;; anonymous function
-                      (kw-identical? :fn op)
-                      ;; special thing like require
-                      (identical? needs-ctx op))
-            env (:env ctx)
-            id (:id ctx)]
-        (when (not special?)
-          (swap! env update-in [:sci.impl/callstack id]
-                 (fn [vt]
-                   (if vt
-                     (do (vswap! vt conj node)
-                         vt)
-                     (volatile! (list node))))))
-        (let [d (ex-data e)
-              wrapping-sci-error? (isa? (:type d) :sci/error)]
-          (if wrapping-sci-error?
-            (throw e)
-            (let [ex-msg #?(:clj (.getMessage e)
-                            :cljs (.-message e))
-                  {:keys [:line :column :file]}
-                  (or (some-> env deref
-                              :sci.impl/callstack (get id)
-                              deref last meta)
-                      (meta node))]
-              (if (and line column)
-                (let [ex-msg (if (and ex-msg (:name fm))
-                               (str/replace ex-msg #"(sci\.impl\.)?fns/fun/[a-zA-Z0-9-]+--\d+"
-                                            (str (:ns fm) "/" (:name fm)))
-                               ex-msg)
-                      new-exception
-                      (let [new-d {:type :sci/error
-                                   :line line
-                                   :column column
-                                   :message ex-msg
-                                   :sci.impl/callstack
-                                   (delay (when-let
-                                              [v (get-in @(:env ctx) [:sci.impl/callstack (:id ctx)])]
-                                            @v))
-                                   :file file
-                                   :locals (:bindings ctx)}]
-                        (ex-info ex-msg new-d e))]
-                  (throw new-exception))
-                (throw e))))))))
+(defn rethrow-with-location-of-node
+  ([ctx ^Throwable e raw-node] (rethrow-with-location-of-node ctx (:bindings ctx) e raw-node))
+  ([ctx bindings ^Throwable e raw-node]
+   (if *in-try* (throw e)
+       (let [node (t/sexpr raw-node)
+             m (meta node)
+             f (when (seqable? node) (first node))
+             fm (some-> f meta)
+             op (when (and fm m)
+                  (.get ^java.util.Map m :sci.impl/op))
+             special? (or
+                       ;; special call like def
+                       (and (symbol? f) (not op))
+                       ;; anonymous function
+                       (kw-identical? :fn op)
+                       ;; special thing like require
+                       (identical? needs-ctx op))
+             env (:env ctx)
+             id (:id ctx)]
+         (when (not special?)
+           (swap! env update-in [:sci.impl/callstack id]
+                  (fn [vt]
+                    (if vt
+                      (do (vswap! vt conj node)
+                          vt)
+                      (volatile! (list node))))))
+         (let [d (ex-data e)
+               wrapping-sci-error? (isa? (:type d) :sci/error)]
+           (if wrapping-sci-error?
+             (throw e)
+             (let [ex-msg #?(:clj (.getMessage e)
+                             :cljs (.-message e))
+                   {:keys [:line :column :file]}
+                   (or (some-> env deref
+                               :sci.impl/callstack (get id)
+                               deref last meta)
+                       (meta node))]
+               (if (and line column)
+                 (let [ex-msg (if (and ex-msg (:name fm))
+                                (str/replace ex-msg #"(sci\.impl\.)?fns/fun/[a-zA-Z0-9-]+--\d+"
+                                             (str (:ns fm) "/" (:name fm)))
+                                ex-msg)
+                       new-exception
+                       (let [new-d {:type :sci/error
+                                    :line line
+                                    :column column
+                                    :message ex-msg
+                                    :sci.impl/callstack
+                                    (delay (when-let
+                                               [v (get-in @(:env ctx) [:sci.impl/callstack (:id ctx)])]
+                                             @v))
+                                    :file file
+                                    :locals bindings}]
+                         (ex-info ex-msg new-d e))]
+                   (throw new-exception))
+                 (throw e)))))))))
 
 (defn iobj? [obj]
   (and #?(:clj (instance? clojure.lang.IObj obj)


### PR DESCRIPTION
This saves lookup and assoc-ing onto the ctx map and yields about 20% performance gain in the loop example:

```
./sci "(time (loop [val 0 cnt 1000000] (if (pos? cnt) (recur (inc val) (dec cnt)) val)))"
```