### PR TITLE
"Varify" more namespaces

### DIFF
--- a/src/sci/impl/namespaces.cljc
+++ b/src/sci/impl/namespaces.cljc
@@ -26,7 +26,7 @@
    [sci.impl.types :as types]
    [sci.impl.utils :as utils :refer [needs-ctx]]
    [sci.impl.vars :as vars])
-  #?(:cljs (:require-macros [sci.impl.namespaces :refer [copy-var copy-core-var]])))
+  #?(:cljs (:require-macros [sci.impl.namespaces :refer [copy-var-with-addl-meta copy-var copy-core-var]])))
 
 #?(:clj (set! *warn-on-reflection* true))
 

--- a/src/sci/impl/namespaces.cljc
+++ b/src/sci/impl/namespaces.cljc
@@ -686,20 +686,22 @@
 ;;;;
 
 #?(:clj
-   (def clojure-lang
-     {:obj (vars/->SciNamespace 'clojure.lang nil)
-      ;; IDeref as protocol instead of class
-      'IDeref core-protocols/deref-protocol
-      'deref core-protocols/deref
-      ;; IAtom as protocol instead of class
-      'IAtom core-protocols/swap-protocol
-      'swap core-protocols/swap
-      'reset core-protocols/reset
-      'compareAndSet core-protocols/compareAndSet
-      'IAtom2 core-protocols/iatom2-protocol
-      'resetVals core-protocols/resetVals
-      'swapVals core-protocols/swapVals
-      }))
+   (do
+     (def clojure-lang-namespace (vars/->SciNamespace 'clojure.lang nil))
+     (def clojure-lang
+       {:obj           clojure-lang-namespace
+        ;; IDeref as protocol instead of class
+        'IDeref        core-protocols/deref-protocol
+        'deref         (copy-var core-protocols/deref clojure-lang-namespace)
+        ;; IAtom as protocol instead of class
+        'IAtom         core-protocols/swap-protocol
+        'swap          (copy-var core-protocols/swap clojure-lang-namespace)
+        'reset         (copy-var core-protocols/reset clojure-lang-namespace)
+        'compareAndSet (copy-var core-protocols/compareAndSet clojure-lang-namespace)
+        'IAtom2        core-protocols/iatom2-protocol
+        'resetVals     (copy-var core-protocols/resetVals clojure-lang-namespace)
+        'swapVals      (copy-var core-protocols/swapVals clojure-lang-namespace)
+        })))
 
 ;;;; REPL vars
 
@@ -1500,8 +1502,10 @@
                             (+ 2 (- (count (.getStackTrace cause))
                                     (count st)))))))))))
 
+(def clojure-repl-namespace (vars/->SciNamespace 'clojure.repl nil))
+
 (def clojure-repl
-  {:obj (vars/->SciNamespace 'clojure.repl nil)
+  {:obj clojure-repl-namespace
    'dir-fn (with-meta dir-fn {:sci.impl/op needs-ctx})
    'dir (macrofy dir)
    'print-doc (with-meta print-doc {:private true})
@@ -1526,10 +1530,12 @@
     `(do ~@(map (fn [a] (apply-template argv expr a))
                 (partition c values)))))
 
+(def clojure-template-namespace (vars/->SciNamespace 'clojure.template nil))
+
 (def clojure-template
-  {:obj (vars/->SciNamespace 'clojure.template nil)
-   'apply-template apply-template
-   'do-template (macrofy do-template)})
+  {:obj clojure-template-namespace
+   'apply-template (copy-var apply-template clojure-template-namespace)
+   'do-template (macrofy 'do-template do-template clojure-template-namespace)})
 
 (def clojure-string-namespace (vars/->SciNamespace 'clojure.string nil))
 (def clojure-set-namespace (vars/->SciNamespace 'clojure.set nil))


### PR DESCRIPTION
I started at the bottom of that list on babashka/babashka#957 , so I did `clojure.template` and `clojure.lang`. In `clojure.repl`, there are a number of vars that need some extra metadata, so I made `copy-var` have a 3-arg alternative that takes a map of metadata to merge in. That's one reason that I stopped here - I look at that as a significant change, so I'd want that reviewed/renamed before it becomes pervasive. The other reason that I stopped here is that it seems like these changes (in my WSL environment) add about 5MB to the babashka executable size. I'm not sure yet if this is just a product of my environment or what, but again, want to review and take any remediation actions before investing too much time.

Basically, just pausing to have a review conversation. 😄 