### PR TITLE
add ns meta to a handful of clojure.core dynamic vars

### DIFF
--- a/src/sci/impl/io.cljc
+++ b/src/sci/impl/io.cljc
@@ -9,26 +9,31 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
+(defn core-dynamic-var
+  "create a dynamic var with clojure.core :ns meta"
+  ([name] (core-dynamic-var name nil))
+  ([name init-val] (vars/dynamic-var name init-val {:ns vars/clojure-core-ns})))
+
 (def in (binding [*unrestricted* true]
-          (doto (vars/dynamic-var '*in*)
-                                        (vars/unbind))))
+          (doto (core-dynamic-var '*in*)
+            (vars/unbind))))
 
 (def out (binding [*unrestricted* true]
-           (doto (vars/dynamic-var '*out*)
+           (doto (core-dynamic-var '*out*)
              (vars/unbind))))
 
 (def err (binding [*unrestricted* true]
-           (doto (vars/dynamic-var '*err*)
+           (doto (core-dynamic-var '*err*)
              (vars/unbind))))
 
 (def print-meta
-  (vars/dynamic-var '*print-meta* false))
+  (core-dynamic-var '*print-meta* false))
 
-(def print-length (vars/dynamic-var '*print-length* nil))
+(def print-length (core-dynamic-var '*print-length*))
 
-(def print-level (vars/dynamic-var '*print-level* nil))
+(def print-level (core-dynamic-var '*print-level*))
 
-(def print-namespace-maps (vars/dynamic-var '*print-namespace-maps* true))
+(def print-namespace-maps (core-dynamic-var '*print-namespace-maps* true))
 
 #?(:clj (defn pr-on
           {:private true

--- a/src/sci/impl/namespaces.cljc
+++ b/src/sci/impl/namespaces.cljc
@@ -755,22 +755,18 @@
 (def core-var
   (ns-new-var clojure-core-ns))
 
-(defn add-core-ns-meta [sci-var]
-  (alter-meta! sci-var assoc :ns clojure-core-ns)
-  sci-var)
-
 (def clojure-core
   {:obj clojure-core-ns
-   '*ns* (add-core-ns-meta vars/current-ns)
+   '*ns* vars/current-ns
    ;; io
-   '*in* (add-core-ns-meta io/in)
-   '*out* (add-core-ns-meta io/out)
-   '*err* (add-core-ns-meta io/err)
-   '*file* (add-core-ns-meta vars/current-file)
-   '*print-length* (add-core-ns-meta io/print-length)
-   '*print-level* (add-core-ns-meta io/print-level)
-   '*print-meta* (add-core-ns-meta io/print-meta)
-   '*print-namespace-maps* (add-core-ns-meta io/print-namespace-maps)
+   '*in* io/in
+   '*out* io/out
+   '*err* io/err
+   '*file* vars/current-file
+   '*print-length* io/print-length
+   '*print-level* io/print-level
+   '*print-meta* io/print-meta
+   '*print-namespace-maps* io/print-namespace-maps
    'newline io/newline
    'flush io/flush
    'pr io/pr

--- a/src/sci/impl/namespaces.cljc
+++ b/src/sci/impl/namespaces.cljc
@@ -755,18 +755,22 @@
 (def core-var
   (ns-new-var clojure-core-ns))
 
+(defn add-core-ns-meta [sci-var]
+  (alter-meta! sci-var assoc :ns clojure-core-ns)
+  sci-var)
+
 (def clojure-core
   {:obj clojure-core-ns
-   '*ns* vars/current-ns
+   '*ns* (add-core-ns-meta vars/current-ns)
    ;; io
-   '*in* io/in
-   '*out* io/out
-   '*err* io/err
-   '*file* vars/current-file
-   '*print-length* io/print-length
-   '*print-level* io/print-level
-   '*print-meta* io/print-meta
-   '*print-namespace-maps* io/print-namespace-maps
+   '*in* (add-core-ns-meta io/in)
+   '*out* (add-core-ns-meta io/out)
+   '*err* (add-core-ns-meta io/err)
+   '*file* (add-core-ns-meta vars/current-file)
+   '*print-length* (add-core-ns-meta io/print-length)
+   '*print-level* (add-core-ns-meta io/print-level)
+   '*print-meta* (add-core-ns-meta io/print-meta)
+   '*print-namespace-maps* (add-core-ns-meta io/print-namespace-maps)
    'newline io/newline
    'flush io/flush
    'pr io/pr

--- a/src/sci/impl/namespaces.cljc
+++ b/src/sci/impl/namespaces.cljc
@@ -30,7 +30,7 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
-(def clojure-core-ns (vars/->SciNamespace 'clojure.core nil))
+(def clojure-core-ns vars/clojure-core-ns)
 
 ;; The following is produced with:
 ;; (def inlined (filter (comp :inline meta) (vals (ns-publics 'clojure.core))))

--- a/src/sci/impl/vars.cljc
+++ b/src/sci/impl/vars.cljc
@@ -388,11 +388,15 @@
    (let [meta (assoc meta :dynamic true)]
      (SciVar. init-val name meta false))))
 
-(def current-file (dynamic-var '*file* nil))
-
+;; rudimentary namespaces
 (def user-ns (->SciNamespace 'user nil))
 
-(def current-ns (dynamic-var '*ns* user-ns))
+(def clojure-core-ns (->SciNamespace 'clojure.core nil))
+
+
+(def current-file (dynamic-var '*file* nil {:ns clojure-core-ns}))
+
+(def current-ns (dynamic-var '*ns* user-ns {:ns clojure-core-ns}))
 
 (defn current-ns-name []
   (getName @current-ns))


### PR DESCRIPTION
Because the vars are already marked dynamic, we can't just use core-var (without adding more arguments or something), so I added the function for just tweaking the metadata on the dynamic vars. As always, I'm happy to revise it if there's a different preferred approach.